### PR TITLE
отбрасывание незначащих нулей в цене транзакции

### DIFF
--- a/src/QuikSharp/DataStructures/Transaction/Transaction.cs
+++ b/src/QuikSharp/DataStructures/Transaction/Transaction.cs
@@ -131,7 +131,7 @@ namespace QuikSharp {
         /// заявка все равно будет исполнена по рыночной цене. Для других рынков при 
         /// выставлении рыночной заявки укажите price= 0.
         /// </summary>
-        [JsonConverter(typeof(ToStringConverter<decimal>))]
+        [JsonConverter(typeof(DecimalG29ToStringConverter))]
         public decimal PRICE { get; set; }
 
         /// <summary>

--- a/src/QuikSharp/Serialization.cs
+++ b/src/QuikSharp/Serialization.cs
@@ -133,6 +133,32 @@ namespace QuikSharp {
     }
 
     /// <summary>
+    /// Serialize Decimal to string without trailing zeros
+    /// </summary>
+    public class DecimalG29ToStringConverter : JsonConverter
+    {
+        public override bool CanConvert(Type objectType) { return objectType.Equals( typeof(decimal) ); }
+
+        public override object ReadJson(JsonReader reader,
+                                        Type objectType,
+                                         object existingValue,
+                                         JsonSerializer serializer)
+        {            
+            var t = JToken.Load(reader);
+            return t.Value<decimal>();            
+        }
+
+        public override void WriteJson(JsonWriter writer,
+                                       object value,
+                                       JsonSerializer serializer)
+        {
+            decimal d = (decimal)value;
+            var t = JToken.FromObject(d.ToString("G29"));
+            t.WriteTo(writer);
+        }
+    }
+
+    /// <summary>
     /// Convert DateTime to HHMMSS
     /// </summary>
     // ReSharper disable once InconsistentNaming

--- a/tests/QuikSharp.Tests/TransactionSpecTest.cs
+++ b/tests/QuikSharp.Tests/TransactionSpecTest.cs
@@ -165,5 +165,20 @@ namespace QuikSharp.Tests {
             Console.WriteLine("Error: " + t.ErrorMessage);
         }
 
+        [Test]
+        public void TransactionPriceWithoutTrailoringZeros()
+        {
+            // Проверка, что в цене отбрасываются незначащие нули, т.к. в противном случае возвращается ошибка:
+            // ошибка отправки транзакции Неправильно указана цена: "81890,000000"
+            // Сообщение об ошибке: Число не может содержать знак разделителя дробной части
+
+            var t1 = new Transaction { PRICE = 1.00000m };
+            var t2 = new Transaction { PRICE = 1.01000m };
+            string json1 = t1.ToJson();
+            string json2 = t2.ToJson();
+
+            Assert.IsTrue(json1.Contains("\"PRICE\":\"1\"}"));
+            Assert.IsTrue(json2.Contains("\"PRICE\":\"1,01\"}") || json2.Contains("\"PRICE\":\"1.01\"}"));
+        }
     }
 }


### PR DESCRIPTION
Данный патч исправляет ошибку для ФОРТС, фьючерса на индекс РТС, если цена содержит разделитель, то при отправке транзакции возникала ошибка. Текст ошибки:
ошибка отправки транзакции Неправильно указана цена: "81890,000000"
Сообщение об ошибке: Число не может содержать знак разделителя дробной части