### PR TITLE
Изменил условие заполнения datasource'а свечами на более стабильное.

### DIFF
--- a/src/QuikSharp/lua/qsfunctions.lua
+++ b/src/QuikSharp/lua/qsfunctions.lua
@@ -329,14 +329,8 @@ end
 function qsfunctions.get_candles_from_data_source(msg)
 	local ds, is_error = create_data_source(msg)
 	if not is_error then
-		local function SetLoaded()
-			loaded = true
-		end
-
 		--- датасорс изначально приходит пустой, нужно некоторое время подождать пока он заполниться данными
-		--- так как время заполнения данными не фиксировано, то за отчет береться первый Update Callback
-		ds:SetUpdateCallback(SetLoaded)
-		repeat sleep(1) until loaded 
+		repeat sleep(1) until ds:Size() > 0
 
 		local count = tonumber(split(msg.data, "|")[4]) --- возвращаем последние count свечей. Если равен 0, то возвращаем все доступные свечи.
 		local class, sec, interval = get_candles_param(msg)

--- a/tests/QuikSharp.Tests/CandleFunctionsTest.cs
+++ b/tests/QuikSharp.Tests/CandleFunctionsTest.cs
@@ -75,9 +75,9 @@ namespace QuikSharp.Tests
 
         private void OnNewCandle(Candle candle)
         {
-            if (candle.Sec == "SBER" && candle.Class == "TQBR" && candle.Interval == CandleInterval.M1)
+            if (candle.SecCode == "SBER" && candle.ClassCode == "TQBR" && candle.Interval == CandleInterval.M1)
             {
-                Console.WriteLine("Sec:{0}, Open:{1}, Close:{2}, Volume:{3}", candle.Sec, candle.Open, candle.Close, candle.Volume);
+                Console.WriteLine("Sec:{0}, Open:{1}, Close:{2}, Volume:{3}", candle.SecCode, candle.Open, candle.Close, candle.Volume);
             }
         }
     }


### PR DESCRIPTION
Предыдущий метод с помощью ds:SetUpdateCallback на некоторых случая начал выдавать ошибки. Датасорс заполнялся только несколькими свечами, а не всеми.

Вариант с ds:Size() > 0 работает стабильно на всех моих сценариях. Но и тут я не уверен, что не появятся специальные случаи.

Пока так предлагаю обкатывать.