### PR TITLE
Heads up: Some internal refactoring

### DIFF
--- a/src/QuikSharp/AsyncManualResetEvent.cs
+++ b/src/QuikSharp/AsyncManualResetEvent.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace QuikSharp {
+    // http://blogs.msdn.com/b/pfxteam/archive/2012/02/11/10266920.aspx
+    internal class AsyncManualResetEvent {
+        private volatile TaskCompletionSource<bool> m_tcs = new TaskCompletionSource<bool>();
+
+        public Task WaitAsync() { return m_tcs.Task; }
+
+        public void Set() { m_tcs.TrySetResult(true); }
+
+        public void Reset() {
+            while (true) {
+                var tcs = m_tcs;
+                if (!tcs.Task.IsCompleted ||
+                    Interlocked.CompareExchange(ref m_tcs, new TaskCompletionSource<bool>(), tcs) == tcs)
+                    return;
+            }
+        }
+    }
+}

--- a/src/QuikSharp/IQuikEvents.cs
+++ b/src/QuikSharp/IQuikEvents.cs
@@ -44,12 +44,12 @@ namespace QuikSharp {
 		/// <summary>
 		/// Событие вызывается когда библиотека QuikSharp успешно подключилась к Quik'у
 		/// </summary>
-		event Action OnConnectedToQuik;
+		event InitHandler OnConnectedToQuik;
 
 		/// <summary>
 		/// Событие вызывается когда библиотека QuikSharp была отключена от Quik'а
 		/// </summary>
-		event Action OnDisconnectedFromQuik;
+		event VoidHandler OnDisconnectedFromQuik;
 
 		event EventHandler OnAccountBalance;
         event EventHandler OnAccountPosition;

--- a/src/QuikSharp/QuikEvents.cs
+++ b/src/QuikSharp/QuikEvents.cs
@@ -15,9 +15,8 @@ namespace QuikSharp {
     /// <summary>
     /// Обработчик события OnInit
     /// </summary>
-    /// <param name="path">Расположение скрипта QuikSharp.lua</param>
     /// <param name="port">Порт обмена данными</param>
-    public delegate void InitHandler(string path, int port);
+    public delegate void InitHandler(int port);
 
     /// <summary>
     /// 
@@ -57,57 +56,45 @@ namespace QuikSharp {
         public QuikEvents(QuikService service) { QuikService = service; }
         public QuikService QuikService { get; private set; }
 
-		/// <summary>
-		/// Событие вызывается когда библиотека QuikSharp успешно подключилась к Quik'у
-		/// </summary>
-		public event Action OnConnectedToQuik;
-		internal void OnConnectedToQuikCall ()
-		{
-			if (OnConnectedToQuik != null)
-				OnConnectedToQuik ();
-		}
+        /// <summary>
+        /// Событие вызывается когда библиотека QuikSharp успешно подключилась к Quik'у
+        /// </summary>
+        public event InitHandler OnConnectedToQuik;
+        internal void OnConnectedToQuikCall(int port) {
+            OnConnectedToQuik?.Invoke(port);
+            OnInit?.Invoke(port);
+        }
 
-		/// <summary>
+        /// <summary>
 		/// Событие вызывается когда библиотека QuikSharp была отключена от Quik'а
 		/// </summary>
-		public event Action OnDisconnectedFromQuik;
-		internal void OnDisconnectedFromQuikCall ()
-		{
-			if (OnDisconnectedFromQuik != null)
-				OnDisconnectedFromQuik ();
-		}
-
-		public event InitHandler OnInit
-		{
-			add
-			{
-				throw new NotImplementedException ("Подписка на данный метод бессымслена. В скрипте lua будет вызван данный callback когда еще нет подключения к QuikSharp библиотеке. Используйте callback OnConnectedToQuikCall если необходимо.");
-			}
-			remove
-			{
-
-			}
-		}
-
-		public event EventHandler OnAccountBalance;
-		public event EventHandler OnAccountPosition;
-
-		/// <summary>
-		/// Функция вызывается терминалом QUIK при получении обезличенной сделки.
-		/// </summary>
-		public event AllTradeHandler OnAllTrade;
-        internal void OnAllTradeCall(AllTrade allTrade) {
-            if (OnAllTrade != null) OnAllTrade(allTrade);
+		public event VoidHandler OnDisconnectedFromQuik;
+        internal void OnDisconnectedFromQuikCall() {
+            OnDisconnectedFromQuik?.Invoke();
         }
+
+        public event InitHandler OnInit;
+
+        public event EventHandler OnAccountBalance;
+        public event EventHandler OnAccountPosition;
+
+        /// <summary>
+        /// Функция вызывается терминалом QUIK при получении обезличенной сделки.
+        /// </summary>
+        public event AllTradeHandler OnAllTrade;
+        internal void OnAllTradeCall(AllTrade allTrade) => OnAllTrade?.Invoke(allTrade);
 
 
         public event VoidHandler OnCleanUp;
-        internal void OnCleanUpCall() { if (OnCleanUp != null) OnCleanUp(); }
+        internal void OnCleanUpCall()
+        {
+            OnCleanUp?.Invoke();
+        }
 
-		/// <summary>
-		/// Функция вызывается перед закрытием терминала QUIK.
-		/// </summary>
-		public event VoidHandler OnClose;
+        /// <summary>
+        /// Функция вызывается перед закрытием терминала QUIK.
+        /// </summary>
+        public event VoidHandler OnClose;
         internal void OnCloseCall() { if (OnClose != null) OnClose(); }
 
 
@@ -125,20 +112,20 @@ namespace QuikSharp {
         }
 
 
-		public event EventHandler OnFirm;
-		public event EventHandler OnFuturesClientHolding;
-		public event EventHandler OnFuturesLimitChange;
-		public event EventHandler OnFuturesLimitDelete;
-		public event EventHandler OnMoneyLimit;
-		public event EventHandler OnMoneyLimitDelete;
-		public event EventHandler OnNegDeal;
-		public event EventHandler OnNegTrade;
+        public event EventHandler OnFirm;
+        public event EventHandler OnFuturesClientHolding;
+        public event EventHandler OnFuturesLimitChange;
+        public event EventHandler OnFuturesLimitDelete;
+        public event EventHandler OnMoneyLimit;
+        public event EventHandler OnMoneyLimitDelete;
+        public event EventHandler OnNegDeal;
+        public event EventHandler OnNegTrade;
 
 
-		/// <summary>
-		/// Функция вызывается терминалом QUIK при получении сделки.
-		/// </summary>
-		public event OrderHandler OnOrder;
+        /// <summary>
+        /// Функция вызывается терминалом QUIK при получении сделки.
+        /// </summary>
+        public event OrderHandler OnOrder;
         internal void OnOrderCall(Order order) {
             if (OnOrder != null) OnOrder(order);
             // invoke event specific for the transaction
@@ -167,25 +154,25 @@ namespace QuikSharp {
         }
 
 
-		public event EventHandler OnParam;
+        public event EventHandler OnParam;
 
 
-		/// <summary>
-		/// Функция вызывается терминалом QUIK при получении изменения стакана котировок.
-		/// </summary>
-		public event QuoteHandler OnQuote;
+        /// <summary>
+        /// Функция вызывается терминалом QUIK при получении изменения стакана котировок.
+        /// </summary>
+        public event QuoteHandler OnQuote;
         internal void OnQuoteCall(OrderBook orderBook) { if (OnQuote != null) OnQuote(orderBook); }
 
-		/// <summary>
-		/// Функция вызывается терминалом QUIK при остановке скрипта из диалога управления и при закрытии терминала QUIK.
-		/// </summary>
-		public event StopHandler OnStop;
+        /// <summary>
+        /// Функция вызывается терминалом QUIK при остановке скрипта из диалога управления и при закрытии терминала QUIK.
+        /// </summary>
+        public event StopHandler OnStop;
         internal void OnStopCall(int signal) { if (OnStop != null) OnStop(signal); }
 
-		/// <summary>
-		/// Функция вызывается терминалом QUIK при получении сделки.
-		/// </summary>
-		public event TradeHandler OnTrade;
+        /// <summary>
+        /// Функция вызывается терминалом QUIK при получении сделки.
+        /// </summary>
+        public event TradeHandler OnTrade;
         internal void OnTradeCall(Trade trade) {
             if (OnTrade != null) OnTrade(trade);
             // invoke event specific for the transaction
@@ -222,10 +209,10 @@ namespace QuikSharp {
             //Trace.Assert(tr != null, "Transaction must exist in persistent storage until it is completed and all trades messages are recieved");
         }
 
-		/// <summary>
-		/// Функция вызывается терминалом QUIK при получении ответа на транзакцию пользователя.
-		/// </summary>
-		public event TransReplyHandler OnTransReply;
+        /// <summary>
+        /// Функция вызывается терминалом QUIK при получении ответа на транзакцию пользователя.
+        /// </summary>
+        public event TransReplyHandler OnTransReply;
         internal void OnTransReplyCall(TransactionReply reply) {
             if (OnTransReply != null) OnTransReply(reply);
 

--- a/src/QuikSharp/QuikService.cs
+++ b/src/QuikSharp/QuikService.cs
@@ -18,24 +18,24 @@ namespace QuikSharp {
     /// 
     /// </summary>
     public class QuikService {
-        private static Dictionary<int, QuikService> _services =
+        private static readonly Dictionary<int, QuikService> Services =
             new Dictionary<int, QuikService>();
         private static readonly object StaticSync = new object();
-		private ManualResetEvent _сonnectEvent = new ManualResetEvent (false);    // Событие будет установлено после того как произойдет подключение
+        private readonly AsyncManualResetEvent _connectedMre = new AsyncManualResetEvent();
 
-		/// <summary>
-		/// For each port only one instance of QuikService
-		/// </summary>
-		public static QuikService Create(int port) {
+        /// <summary>
+        /// For each port only one instance of QuikService
+        /// </summary>
+        public static QuikService Create(int port) {
             lock (StaticSync) {
                 QuikService service;
-                if (_services.ContainsKey(port)) {
-                    service = _services[port];
+                if (Services.ContainsKey(port)) {
+                    service = Services[port];
                     service.Start();
                 } else {
                     service = new QuikService(port);
-                    _services.Add(port, service);
-				}
+                    Services.Add(port, service);
+                }
                 return service;
             }
         }
@@ -67,10 +67,16 @@ namespace QuikSharp {
         private TcpClient _responseClient;
         private TcpClient _callbackClient;
 
-        private readonly Object _syncRoot = new object();
+        private readonly object _syncRoot = new object();
+
+
+        private Task _requestTask;
+        private Task _responseTask;
+        private Task _callbackTask;
 
         private CancellationTokenSource _cts;
-
+        private TaskCompletionSource<bool> _cancelledTcs;
+        private CancellationTokenRegistration _cancelRegistration;
         /// <summary>
         /// Current correlation id. Use Interlocked.Increment to get a new id.
         /// </summary>
@@ -94,22 +100,29 @@ namespace QuikSharp {
             if (!IsStarted) return;
             IsStarted = false;
             _cts.Cancel();
+            _cancelRegistration.Dispose();
+
+            // here all tasks must exit gracefully
+            var isCleanExit = Task.WaitAll(new[] { _requestTask, _responseTask, _callbackTask }, 5000);
+            Trace.Assert(isCleanExit, "All tasks must finish gracefully after cancellation token is cancelled!");
         }
 
-		/// <summary>
-		/// 
-		/// </summary>
-		/// <exception cref="ApplicationException">Response message id does not exists in results dictionary</exception>
-		public void Start() {
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <exception cref="ApplicationException">Response message id does not exists in results dictionary</exception>
+        public void Start() {
             if (IsStarted) return;
             IsStarted = true;
             _cts = new CancellationTokenSource();
+            _cancelledTcs = new TaskCompletionSource<bool>();
+            _cancelRegistration = _cts.Token.Register(() => _cancelledTcs.TrySetResult(true));
 
             // Request Task
-            Task.Factory.StartNew(() => {
+            _requestTask = Task.Factory.StartNew(() => {
                 try {
                     // Enter the listening loop. 
-                    while (!_cts.IsCancellationRequested) {		// Обращение к потоко-небезопастному свойству IsStarted - не хорошо... Там токен завершения зачем передается ?!?
+                    while (!_cts.IsCancellationRequested) {
                         Trace.WriteLine("Connecting on request/response channel... ");
                         EnsureConnectedClient();
                         // here we have a connected TCP client
@@ -119,273 +132,263 @@ namespace QuikSharp {
                             var writer = new StreamWriter(stream);
                             while (!_cts.IsCancellationRequested) {
                                 IMessage message = null;
-								try
-								{
-									// BLOCKING
-									message = EnvelopeQueue.Take (_cts.Token);
-									var request = message.ToJson ();
-									//Trace.WriteLine("Request: " + request);
-									// scenario: Quik is restarted or script is stopped
-									// then writer must throw and we will add a message back
-									// then we will iterate over messages and cancel expired ones
-									if (!message.ValidUntil.HasValue || message.ValidUntil >= DateTime.UtcNow)
-									{
-										writer.WriteLine (request);
-										writer.Flush ();
-									}
-									else
-									{
-										Trace.Assert (message.Id.HasValue, "All requests must have correlation id");
-										Responses [message.Id.Value].Key.SetException (
-											new TimeoutException ("ValidUntilUTC is less than current time"));
-										KeyValuePair<TaskCompletionSource<IMessage>, Type> tcs; // <IMessage>
-										Responses.TryRemove (message.Id.Value, out tcs);
-									}
-								}
-								catch (OperationCanceledException) { }  // Мы получим такое исключение при отмене операции. Все нормально - исключение логировать не нужно!
-								catch (IOException)
-								{
-									// this catch is for unexpected and unchecked connection termination
-									// add back, there was an error while writing
-									if (message != null)
-									{ EnvelopeQueue.Add (message); }
-									break;
-								}
+                                try {
+                                    // BLOCKING
+                                    message = EnvelopeQueue.Take(_cts.Token);
+                                    var request = message.ToJson();
+                                    //Trace.WriteLine("Request: " + request);
+                                    // scenario: Quik is restarted or script is stopped
+                                    // then writer must throw and we will add a message back
+                                    // then we will iterate over messages and cancel expired ones
+                                    if (!message.ValidUntil.HasValue || message.ValidUntil >= DateTime.UtcNow) {
+                                        writer.WriteLine(request);
+                                        writer.Flush();
+                                    } else {
+                                        Trace.Assert(message.Id.HasValue, "All requests must have correlation id");
+                                        Responses[message.Id.Value].Key.SetException(
+                                            new TimeoutException("ValidUntilUTC is less than current time"));
+                                        KeyValuePair<TaskCompletionSource<IMessage>, Type> tcs; // <IMessage>
+                                        Responses.TryRemove(message.Id.Value, out tcs);
+                                    }
+                                } catch (OperationCanceledException) {
+                                    // EnvelopeQueue.Take(_cts.Token) was cancelled via the token
+                                } catch (IOException) {
+                                    // this catch is for unexpected and unchecked connection termination
+                                    // add back, there was an error while writing
+                                    if (message != null) { EnvelopeQueue.Add(message); }
+                                    break;
+                                }
                             }
                         } catch (IOException e) {
-                            Trace.TraceError (e.ToString ());
+                            Trace.TraceError(e.ToString());
                         }
                     }
                 } catch (Exception e) {
-					Trace.TraceError  (e.ToString ());
+                    Trace.TraceError(e.ToString());
+                    Environment.FailFast("Unhandled exception in background task", e);
                 } finally {
                     try {
                         Monitor.Enter(_syncRoot);
                         if (_responseClient != null) {
                             _responseClient.Client.Shutdown(SocketShutdown.Both);
                             _responseClient.Close();
-							_responseClient = null;     // У нас два потока работают с одним сокетом, но только один из них должен его закрыть !
-							Trace.WriteLine ("Response channel disconnected");
-						}
+                            _responseClient = null;     // У нас два потока работают с одним сокетом, но только один из них должен его закрыть !
+                            Trace.WriteLine("Response channel disconnected");
+                        }
                     } finally {
                         Monitor.Exit(_syncRoot);
                     }
                 }
-            }, _cts.Token, TaskCreationOptions.LongRunning, TaskScheduler.Default);
+            },
+            CancellationToken.None, // NB we use the token for signalling, could use a simple TCS
+            TaskCreationOptions.LongRunning,
+            TaskScheduler.Default);
 
             // Response Task
-            Task.Factory.StartNew(async () => {
+            _responseTask = Task.Factory.StartNew(async () => {
                 try {
                     while (!_cts.IsCancellationRequested) {
-                       
-						// Поток Response использует тот же сокет, что и поток request
+
+                        // Поток Response использует тот же сокет, что и поток request
                         EnsureConnectedClient();
-						// here we have a connected TCP client
+                        // here we have a connected TCP client
 
-						try
-						{
-							var stream = new NetworkStream (_responseClient.Client);
-							var reader = new StreamReader (stream, Encoding.GetEncoding (1251)); //true
-							while (!_cts.IsCancellationRequested)
-							{
+                        try {
+                            var stream = new NetworkStream(_responseClient.Client);
+                            var reader = new StreamReader(stream, Encoding.GetEncoding(1251)); //true
+                            while (!_cts.IsCancellationRequested) {
+                                var readLineTask = reader.ReadLineAsync();
+                                var lineOrCancelledTask = await Task.WhenAny(readLineTask, _cancelledTcs.Task).ConfigureAwait(false);
+                                if (lineOrCancelledTask == _cancelledTcs.Task) {
+                                    break;
+                                }
+                                Trace.Assert(readLineTask.Status == TaskStatus.RanToCompletion);
+                                var response = readLineTask.Result;
+                                if (response == null) {
+                                    throw new IOException("Lua returned an empty response or closed the connection");
+                                }
 
-								// Запускаем ReadLineAsync с CancellationToken. Подсмотрел тут https://habrahabr.ru/post/238377/
-								var taskRead = reader.ReadLineAsync ()
-									.ContinueWith (
-										t => t.GetAwaiter ().GetResult (),
-										_cts.Token,
-										TaskContinuationOptions.ExecuteSynchronously,
-										TaskScheduler.Default
-									);
-								var response = await taskRead.ConfigureAwait (false);
-								if (response == null)
-								{
-									throw new IOException ("Lua returned an empty response or closed the connection");
-								}
+                                // No IO exceptions possible for response, move its processing
+                                // to the threadpool and wait for the next mesaage
+                                // A new task here gives c.30% boost for full TransactionSpec echo
 
-								// No IO exceptions possible for response, move its processing
-								// to the threadpool and wait for the next mesaage
-								// A new task here gives c.30% boost for full TransactionSpec echo
+                                // ReSharper disable once UnusedVariable
+                                var doNotAwaitMe = Task.Factory.StartNew(r => {
+                                    //var r = response;
+                                    //Trace.WriteLine("Response:" + response);
+                                    try {
 
-								// ReSharper disable once UnusedVariable
-								var doNotAwaitMe = Task.Factory.StartNew (r =>
-								{
-									//var r = response;
-									//Trace.WriteLine("Response:" + response);
-									try
-									{
+                                        var message = (r as string).FromJson(this);
+                                        Trace.Assert(message.Id.HasValue && message.Id > 0);
+                                        // it is a response message
+                                        if (!Responses.ContainsKey(message.Id.Value))
+                                            throw new ApplicationException("Unexpected correlation ID");
+                                        KeyValuePair<TaskCompletionSource<IMessage>, Type> tcs;
+                                        Responses.TryRemove(message.Id.Value, out tcs);
+                                        if (!message.ValidUntil.HasValue || message.ValidUntil >= DateTime.UtcNow) {
+                                            tcs.Key.SetResult(message);
+                                        } else {
+                                            tcs.Key.SetException(
+                                                new TimeoutException("ValidUntilUTC is less than current time"));
+                                        }
 
-										var message = (r as string).FromJson (this);
-										Trace.Assert (message.Id.HasValue && message.Id > 0);
-										// it is a response message
-										if (!Responses.ContainsKey (message.Id.Value))
-											throw new ApplicationException ("Unexpected correlation ID");
-										KeyValuePair<TaskCompletionSource<IMessage>, Type> tcs;
-										Responses.TryRemove (message.Id.Value, out tcs);
-										if (!message.ValidUntil.HasValue || message.ValidUntil >= DateTime.UtcNow)
-										{
-											tcs.Key.SetResult (message);
-										}
-										else
-										{
-											tcs.Key.SetException (
-												new TimeoutException ("ValidUntilUTC is less than current time"));
-										}
+                                    } catch (LuaException e) {
+                                        Trace.TraceError(e.ToString());
+                                    }
+                                }, response, TaskCreationOptions.PreferFairness);
 
-									}
-									catch (LuaException)
-									{
-										Trace.TraceError ("Caught Lua exception");
-									}
-								}, response, TaskCreationOptions.PreferFairness);
-
-							}
-						}
-						catch (TaskCanceledException) { }     // Это исключение возникнет при отмене ReadLineAsync через Cancellation Token
-						catch (IOException e) {
-							Trace.TraceError (e.ToString ());
+                            }
+                        } catch (TaskCanceledException) { }     // Это исключение возникнет при отмене ReadLineAsync через Cancellation Token
+                        catch (IOException e) {
+                            Trace.TraceError(e.ToString());
                         }
                     }
                 } catch (Exception e) {
-					Trace.TraceError (e.ToString ());
+                    Trace.TraceError(e.ToString());
+                    Environment.FailFast("Unhandled exception in background task", e);
                 } finally {
                     try {
                         Monitor.Enter(_syncRoot);
                         if (_responseClient != null) {
                             _responseClient.Client.Shutdown(SocketShutdown.Both);
                             _responseClient.Close();
-							_responseClient = null;     // У нас два потока работают с одним сокетом, но только один из них должен его закрыть !
-							Trace.WriteLine ("Response channel disconnected");
-						}
+                            _responseClient = null;     // У нас два потока работают с одним сокетом, но только один из них должен его закрыть !
+                            Trace.WriteLine("Response channel disconnected");
+                        }
                     } finally {
                         Monitor.Exit(_syncRoot);
                     }
                 }
-            }, _cts.Token, TaskCreationOptions.LongRunning, TaskScheduler.Default);
+            },
+            CancellationToken.None, // NB we use the token for signalling, could use a simple TCS
+            TaskCreationOptions.LongRunning,
+            TaskScheduler.Default);
 
 
             // Callback Task
-            Task.Factory.StartNew(async () => {
+            _callbackTask = Task.Factory.StartNew(async () => {
                 try {
+                    // reconnection loop
                     while (!_cts.IsCancellationRequested) {
                         Trace.WriteLine("Connecting on callback channel... ");
                         EnsureConnectedClient();
-						this.Events.OnConnectedToQuikCall ();       // Оповещаем клиента что произошло подключение к Quik'у
-						_сonnectEvent.Set ();
+                        // now we are connected
+                        this.Events.OnConnectedToQuikCall(_responsePort);       // Оповещаем клиента что произошло подключение к Quik'у
+                        _connectedMre.Set();
 
-						// here we have a connected TCP client
-						Trace.WriteLine("Callback channel connected");
-						try
-						{
-							var stream = new NetworkStream (_callbackClient.Client);
-							var reader = new StreamReader (stream, Encoding.GetEncoding (1251)); //true
-							while (!_cts.IsCancellationRequested)
-							{
+                        // here we have a connected TCP client
+                        Trace.WriteLine("Callback channel connected");
+                        try {
+                            var stream = new NetworkStream(_callbackClient.Client);
+                            var reader = new StreamReader(stream, Encoding.GetEncoding(1251)); //true
+                            while (!_cts.IsCancellationRequested) {
+                                var readLineTask = reader.ReadLineAsync();
+                                var lineOrCancelledTask = await Task.WhenAny(readLineTask, _cancelledTcs.Task).ConfigureAwait(false);
+                                if (lineOrCancelledTask == _cancelledTcs.Task) {
+                                    break;
+                                }
+                                Trace.Assert(readLineTask.Status == TaskStatus.RanToCompletion);
+                                var response = readLineTask.Result;
+                                if (response == null) {
+                                    throw new IOException("Lua returned an empty response or closed the connection");
+                                }
 
-								// Запускаем ReadLineAsync с CancellationToken. Подсмотрел тут https://habrahabr.ru/post/238377/
-								var taskRead = reader.ReadLineAsync ()
-									.ContinueWith (
-										t => t.GetAwaiter ().GetResult (),
-										_cts.Token,
-										TaskContinuationOptions.ExecuteSynchronously,
-										TaskScheduler.Default
-									);
-								var callback = await taskRead.ConfigureAwait (false);
-								if (callback == null)
-								{
-									throw new IOException ("Lua returned an empty response or closed the connection");
-								}
+                                // No IO exceptions possible for response, move its processing
+                                // to the threadpool and wait for the next message
+                                // A new task here gives c.30% boost for full TransactionSpec echo
 
-								// No IO exceptions possible for response, move its processing
-								// to the threadpool and wait for the next mesaage
-								// A new task here gives c.30% boost for full TransactionSpec echo
+                                // ReSharper disable once UnusedVariable
+                                var doNotAwaitMe = Task.Factory.StartNew(r => {
+                                    try {
+                                        var message = (r as string).FromJson(this);
+                                        Trace.Assert(!(message.Id.HasValue && message.Id > 0));
+                                        // it is a callback message
+                                        ProcessCallbackMessage(message);
+                                    } catch (LuaException e) {
+                                        Trace.TraceError(e.ToString());
+                                    }
+                                }, response, TaskCreationOptions.PreferFairness);
 
-								// ReSharper disable once UnusedVariable
-								var doNotAwaitMe = Task.Factory.StartNew (r =>
-								{
-									//var r = response;
-									//Trace.WriteLine("Response:" + response);
-									try
-									{
-
-										var message = (r as string).FromJson (this);
-										Trace.Assert (!(message.Id.HasValue && message.Id > 0));
-										// it is a callback message
-										ProcessCallbackMessage (message);
-
-									}
-									catch (LuaException)
-									{
-										Trace.TraceError ("Caught Lua exception");
-									}
-								}, callback, TaskCreationOptions.PreferFairness);
-
-							}
-						}
-						catch (TaskCanceledException) { }     // Это исключение возникнет при отмене ReadLineAsync через Cancellation Token
-						catch (IOException e)
-						{
-							Trace.TraceError (e.ToString ());
-						}
+                            }
+                        } catch (IOException e) {
+                            Trace.TraceError(e.ToString());
+                            if (!IsServiceConnected()) {
+                                // handled exception will cause reconnect in the outer loop
+                                _connectedMre.Reset();
+                                this.Events.OnDisconnectedFromQuikCall();
+                            } else {
+                                throw;
+                            }
+                        }
                     }
                 } catch (Exception e) {
-					Trace.TraceError (e.ToString ());
+                    Trace.TraceError(e.ToString());
+                    Environment.FailFast("Unhandled exception in background task", e);
                 } finally {
                     try {
                         Monitor.Enter(_syncRoot);
                         if (_callbackClient != null) {
                             _callbackClient.Client.Shutdown(SocketShutdown.Both);
                             _callbackClient.Close();
-							_callbackClient = null;
-							Trace.WriteLine ("Callback channel disconnected");
-
-						}
+                            _callbackClient = null;
+                            Trace.WriteLine("Callback channel disconnected");
+                        }
                     } finally {
                         Monitor.Exit(_syncRoot);
-						this.Events.OnDisconnectedFromQuikCall ();
-						_сonnectEvent.Reset ();
-					}
+                    }
                 }
-            }, _cts.Token, TaskCreationOptions.LongRunning, TaskScheduler.Default);
+            },
+            CancellationToken.None, // NB we use the token for signalling, could use a simple TCS
+            TaskCreationOptions.LongRunning,
+            TaskScheduler.Default);
+
+        }
 
 
+        private bool IsServiceConnected() {
+            return (_responseClient != null && _responseClient.Connected && _responseClient.Client.IsConnectedNow())
+                   && (_callbackClient != null && _callbackClient.Connected && _callbackClient.Client.IsConnectedNow());
         }
 
         private void EnsureConnectedClient() {
             try {
                 Monitor.Enter(_syncRoot);
-               
-                    if (!(_responseClient != null && _responseClient.Connected && _responseClient.Client.IsConnectedNow())) {
-                        var connected = false;
-                        while (!connected) {
-                            try {
-                                _responseClient = new TcpClient {
-                                    ExclusiveAddressUse = true,
-                                    NoDelay = true
-                                };
-                                _responseClient.Connect(_host, _responsePort);
-                                connected = true;
-                            } catch {
-                                //Trace.WriteLine("Trying to connect...");
-                            }
-                        }
-                }
-
-                    if (!(_callbackClient != null && _callbackClient.Connected && _callbackClient.Client.IsConnectedNow())) {
-                        var connected = false;
-                        while (!connected) {
-                            try {
-                                _callbackClient = new TcpClient {
-                                    ExclusiveAddressUse = true,
-                                    NoDelay = true
-                                };
-                                _callbackClient.Connect(_host, _callbackPort);
-                                connected = true;
-                            } catch {
-                                //Trace.WriteLine("Trying to connect...");
-                            }
+                var attempt = 0;
+                if (!(_responseClient != null && _responseClient.Connected && _responseClient.Client.IsConnectedNow())) {
+                    var connected = false;
+                    while (!connected) {
+                        try {
+                            _responseClient = new TcpClient {
+                                ExclusiveAddressUse = true,
+                                NoDelay = true
+                            };
+                            _responseClient.Connect(_host, _responsePort);
+                            connected = true;
+                        } catch {
+                            attempt++;
+                            Thread.Sleep(100);
+                            if (attempt % 10 == 0) Trace.WriteLine($"Trying to connect... {attempt}");
                         }
                     }
+                }
+
+                if (!(_callbackClient != null && _callbackClient.Connected && _callbackClient.Client.IsConnectedNow())) {
+                    var connected = false;
+                    while (!connected) {
+                        try {
+                            _callbackClient = new TcpClient {
+                                ExclusiveAddressUse = true,
+                                NoDelay = true
+                            };
+                            _callbackClient.Connect(_host, _callbackPort);
+                            connected = true;
+                        } catch {
+                            attempt++;
+                            Thread.Sleep(100);
+                            if (attempt % 10 == 0) Trace.WriteLine($"Trying to connect... {attempt}");
+                        }
+                    }
+                }
             } finally { Monitor.Exit(_syncRoot); }
         }
 
@@ -394,6 +397,7 @@ namespace QuikSharp {
             EventNames eventName;
             var parsed = Enum.TryParse(message.Command, true, out eventName);
             if (parsed) {
+                // TODO use as instead of assert+is+cast
                 switch (eventName) {
                     case EventNames.OnAccountBalance:
                         break;
@@ -436,7 +440,7 @@ namespace QuikSharp {
                         break;
                     case EventNames.OnInit:
                         // Этот callback никогда не будет вызван так как на момент получения вызова OnInit в lua скрипте
-						// соединение с библиотекой QuikSharp не будет еще установлено. То есть этот callback не имеет смысла.
+                        // соединение с библиотекой QuikSharp не будет еще установлено. То есть этот callback не имеет смысла.
                         break;
                     case EventNames.OnMoneyLimit:
                         break;
@@ -470,7 +474,8 @@ namespace QuikSharp {
                         break;
 
                     case EventNames.OnStopOrder:
-                        StopOrder stopOrder = (message as Message<StopOrder>).Data;
+                        Trace.Assert(message is Message<StopOrder>);
+                        StopOrder stopOrder = ((Message<StopOrder>)message).Data;
                         StopOrders.RaiseNewStopOrderEvent(stopOrder);
                         break;
 
@@ -489,7 +494,8 @@ namespace QuikSharp {
                         break;
 
                     case EventNames.NewCandle:
-                        Candle candle = (message as Message<Candle>).Data;
+                        Trace.Assert(message is Message<Candle>);
+                        var candle = ((Message<Candle>)message).Data;
                         Candles.RaiseNewCandleEvent(candle);
                         break;
 
@@ -531,8 +537,7 @@ namespace QuikSharp {
         /// Устанавливает стартовое значение для CorrelactionId.
         /// </summary>
         /// <param name="startCorrelationId">Стартовое значение.</param>
-        internal void InitializeCorrelationId(int startCorrelationId)
-        {
+        internal void InitializeCorrelationId(int startCorrelationId) {
             _correlationId = startCorrelationId;
         }
 
@@ -542,26 +547,34 @@ namespace QuikSharp {
 
         internal async Task<TResponse> Send<TResponse>(IMessage request, int timeout = 0)
             where TResponse : class, IMessage, new() {
-
-			// Если мы не подключились к Quik'у продолжение данной функции приведет к полной блокировке в GetNewUniqueId на StaticSync
-			// Если в течении секунды подключение не произошло - вылетит исключение. 
-			// Ожидание 1 секунду нужно, что бы исключение не получали вызовы функций QuikSharp'а, которые вызываются сразу же после создание объекта Quik'a.
-			if (!_сonnectEvent.WaitOne (1000))
-				throw new InvalidOperationException ("Please start QUIK first and run the lua script");
+            var task = _connectedMre.WaitAsync();
+            if (await Task.WhenAny(task, Task.Delay(timeout)).ConfigureAwait(false) == task) {
+                // task completed within timeout, do nothing
+            } else {
+                // timeout
+                throw new TimeoutException("Send operation timed out");
+            }
 
             var tcs = new TaskCompletionSource<IMessage>();
-            if (timeout > 0) {
-                var ct = new CancellationTokenSource(timeout);
-                ct.Token.Register(() => tcs.TrySetCanceled(), false);
-            }
+            var ctRegistration = default(CancellationTokenRegistration);
+
             var kvp = new KeyValuePair<TaskCompletionSource<IMessage>, Type>(tcs, typeof(TResponse));
             if (request.Id == null) {
                 request.Id = GetNewUniqueId();
             }
+            if (timeout > 0) {
+                var ct = new CancellationTokenSource(timeout);
+                ctRegistration = ct.Token.Register(() => {
+                    tcs.TrySetException(new TimeoutException("Send operation timed out"));
+                    KeyValuePair<TaskCompletionSource<IMessage>, Type> temp;
+                    Responses.TryRemove(request.Id.Value, out temp);
+                }, false);
+            }
             Responses[request.Id.Value] = kvp;
             // add to queue after responses dictionary
             EnvelopeQueue.Add(request);
-            var response = await tcs.Task.ConfigureAwait (false);
+            var response = await tcs.Task.ConfigureAwait(false);
+            if (timeout > 0) { ctRegistration.Dispose(); }
             return (response as TResponse);
         }
 

--- a/src/QuikSharp/QuikSharp.csproj
+++ b/src/QuikSharp/QuikSharp.csproj
@@ -132,6 +132,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="CandleFunctions.cs" />
+    <Compile Include="AsyncManualResetEvent.cs" />
     <Compile Include="ClassFunctions\ClassFunctions.cs" />
     <Compile Include="DataStructures\Candle.cs" />
     <Compile Include="DataStructures\CandleInterval.cs" />


### PR DESCRIPTION
Some minor breaking changes are already in master, but this branch has some more. Mostly this is revert & rework of #62 with the following changes:

* ReadLineAsync could not be canceled with ContinueWith, because RLA must finish before CW is scheduled. Task.WhenAny is the way to go.
* Use async MRE
* IsInit is the same as OnConnectedToQuik
* Send should never throw, but await on MRE until connected. It should check connection with the timeout and clean response dict on timeout. Fix missing dispose of CTRegistration.

@nubick @stanislav-111 review please!