### PR TITLE
Added enum ParamNames for function GetParamEx

### DIFF
--- a/Examples/QuikSharpDemo/FormMain.cs
+++ b/Examples/QuikSharpDemo/FormMain.cs
@@ -23,7 +23,7 @@ namespace QuikSharpDemo
         bool isServerConnected = false;
         bool isSubscribedToolOrderBook = false;
         bool isSubscribedToolCandles = false;
-        string secCode = "SRH7";
+        string secCode = "GZM8";
         string classCode = "";
         string clientCode;
         decimal bid;

--- a/Examples/QuikSharpDemo/Tool.cs
+++ b/Examples/QuikSharpDemo/Tool.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using QuikSharp;
+using QuikSharp.DataStructures;
 
 public class Tool   
 {
@@ -97,8 +98,10 @@ public class Tool
                         name = quik.Class.GetSecurityInfo(classCode, securityCode).Result.ShortName;
                         accountID = quik.Class.GetTradeAccount(classCode).Result;
                         firmID = quik.Class.GetClassInfo(classCode).Result.FirmId;
-                        step = Convert.ToDecimal(quik.Trading.GetParamEx(classCode, securityCode, "SEC_PRICE_STEP").Result.ParamValue.Replace('.', separator));
-                        priceAccuracy = Convert.ToInt32(Convert.ToDouble(quik.Trading.GetParamEx(classCode, securityCode, "SEC_SCALE").Result.ParamValue.Replace('.', separator)));
+                        //step = Convert.ToDecimal(quik.Trading.GetParamEx(classCode, securityCode, "SEC_PRICE_STEP").Result.ParamValue.Replace('.', separator));
+                        //priceAccuracy = Convert.ToInt32(Convert.ToDouble(quik.Trading.GetParamEx(classCode, securityCode, "SEC_SCALE").Result.ParamValue.Replace('.', separator)));
+                        step = Convert.ToDecimal(quik.Trading.GetParamEx(classCode, securityCode, ParamNames.SEC_PRICE_STEP).Result.ParamValue.Replace('.', separator));
+                        priceAccuracy = Convert.ToInt32(Convert.ToDouble(quik.Trading.GetParamEx(classCode, securityCode, ParamNames.SEC_SCALE).Result.ParamValue.Replace('.', separator)));
                     }
                     catch (Exception e)
                     {
@@ -109,12 +112,14 @@ public class Tool
                     {
                         Console.WriteLine("Получаем 'guaranteeProviding'.");
                         lot = 1;
-                        guaranteeProviding = Convert.ToDouble(quik.Trading.GetParamEx(classCode, securityCode, "BUYDEPO").Result.ParamValue.Replace('.', separator));
+                        //guaranteeProviding = Convert.ToDouble(quik.Trading.GetParamEx(classCode, securityCode, "BUYDEPO").Result.ParamValue.Replace('.', separator));
+                        guaranteeProviding = Convert.ToDouble(quik.Trading.GetParamEx(classCode, securityCode, ParamNames.BUYDEPO).Result.ParamValue.Replace('.', separator));
                     }
                     else
                     {
                         Console.WriteLine("Получаем 'lot'.");
-                        lot = Convert.ToInt32(Convert.ToDouble(quik.Trading.GetParamEx(classCode, securityCode, "LOTSIZE").Result.ParamValue.Replace('.', separator)));
+                        //lot = Convert.ToInt32(Convert.ToDouble(quik.Trading.GetParamEx(classCode, securityCode, "LOTSIZE").Result.ParamValue.Replace('.', separator)));
+                        lot = Convert.ToInt32(Convert.ToDouble(quik.Trading.GetParamEx(classCode, securityCode, ParamNames.LOTSIZE).Result.ParamValue.Replace('.', separator)));
                         guaranteeProviding = 0;
                     }
                 }

--- a/src/QuikSharp/DataStructures/ParamNames.cs
+++ b/src/QuikSharp/DataStructures/ParamNames.cs
@@ -1,0 +1,372 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace QuikSharp.DataStructures
+{
+    public enum ParamNames
+    {
+        /// <summary>
+        /// Код бумаги
+        /// </summary>
+        CODE,
+        /// <summary>
+        /// Код класса
+        /// </summary>
+        CLASS_CODE,
+        /// <summary>
+        /// Краткое название бумаги
+        /// </summary>
+        SHORTNAME,
+        /// <summary>
+        /// Полное зназвание бумаги
+        /// </summary>
+        LONGNAME,
+        /// <summary>
+        /// Кратность лота
+        /// </summary>
+        LOT,
+        /// <summary>
+        /// Тип инструмента
+        /// </summary>
+        SECTYPESTATIC,
+        /// <summary>
+        /// Тип фьючерса
+        /// </summary>
+        FUTURETYPE,
+        /// <summary>
+        /// Минимальный шаг цены
+        /// </summary>
+        SEC_PRICE_STEP,
+        /// <summary>
+        /// Название класса
+        /// </summary>
+        CLASSNAME,
+        /// <summary>
+        /// Размер лота
+        /// </summary>
+        LOTSIZE,
+        /// <summary>
+        /// Стоимость шага цены
+        /// </summary>
+        STEPPRICET,
+        /// <summary>
+        /// Стоимость шага цены
+        /// </summary>
+        STEPPRICE,
+        /// <summary>
+        /// Стоимость шага цены для клиринга
+        /// </summary>
+        STEPPRICECL,
+        /// <summary>
+        /// Стоимость шага цены для промклиринга
+        /// </summary>
+        STEPPRICEPRCL,
+        /// <summary>
+        /// Точность цены
+        /// </summary>
+        SEC_SCALE,
+        /// <summary>
+        /// Цена закрытия
+        /// </summary>
+        PREVPRICE,
+        /// <summary>
+        /// Цена первой сделки в текущей сессии
+        /// </summary>
+        FIRSTOPEN,
+        /// <summary>
+        /// Цена последней сделки
+        /// </summary>
+        LAST,
+        /// <summary>
+        /// Цена последней сделки в текущей сессии
+        /// </summary>
+        LASTCLOSE,
+        /// <summary>
+        /// Время последней сделки
+        /// </summary>
+        TIME,
+        /// <summary>
+        /// Базовый актив
+        /// </summary>
+        OPTIONBASE,
+        /// <summary>
+        /// Класс базового актива
+        /// </summary>
+        OPTIONBASECLASS,
+        /// <summary>
+        /// Валюта номинала
+        /// </summary>
+        SEC_FACE_UNIT,
+        /// <summary>
+        /// Валюта шага цены
+        /// </summary>
+        CURSTEPPRICE,
+        /// <summary>
+        /// Лучшая цена предложения
+        /// </summary>
+        OFFER,
+        /// <summary>
+        /// Лучшая цена спроса
+        /// </summary>
+        BID,
+        /// <summary>
+        /// Количество заявок на покупку
+        /// </summary>
+        NUMBIDS,
+        /// <summary>
+        /// Количество заявок на продажу
+        /// </summary>
+        NUMOFFERS,
+        /// <summary>
+        /// Спрос по лучшей цене
+        /// </summary>
+        BIDDEPTH,
+        /// <summary>
+        /// Предложение по лучшей цене
+        /// </summary>
+        OFFERDEPTH,
+        /// <summary>
+        /// Суммарный спрос
+        /// </summary>
+        BIDDEPTHT,
+        /// <summary>
+        /// Суммарное предложение
+        /// </summary>
+        OFFERDEPTHT,
+        /// <summary>
+        /// Максимальная цена сделки
+        /// </summary>
+        HIGH,
+        /// <summary>
+        /// Минимальная цена сделки
+        /// </summary>
+        LOW,
+        /// <summary>
+        /// Максимально возможная цена
+        /// </summary>
+        PRICEMAX,
+        /// <summary>
+        /// Минимально возможная цена
+        /// </summary>
+        PRICEMIN,
+        /// <summary>
+        /// Количество открытых позиций
+        /// </summary>
+        NUMCONTRACTS,
+        /// <summary>
+        /// Гарантийное обеспечение покуптеля
+        /// </summary>
+        BUYDEPO,
+        /// <summary>
+        /// Гарантийное обеспечение продавца
+        /// </summary>
+        SELLDEPO,
+        /// <summary>
+        /// Номинал бумаги
+        /// </summary>
+        SEC_FACE_VALUE,
+        /// <summary>
+        /// Дата исполнения инструмента
+        /// </summary>
+        EXPDATE,
+        /// <summary>
+        /// Дата погашения
+        /// </summary>
+        MAT_DATE,
+        /// <summary>
+        /// Число дней до погашения
+        /// </summary>
+        DAYS_TO_MAT_DATE,
+        /// <summary>
+        /// Начало утренней сессии
+        /// </summary>
+        MONSTARTTIME,
+        /// <summary>
+        /// Окончание утренней сессии
+        /// </summary>
+        MONENDTIME,
+        /// <summary>
+        /// Начало вечерней сессии
+        /// </summary>
+        EVNSTARTTIME,
+        /// <summary>
+        /// Окончание вечерней сессии
+        /// </summary>
+        EVNENDTIME,
+        /// <summary>
+        /// Состояние сессии
+        /// </summary>
+        TRADINGSTATUS,
+        /// <summary>
+        /// Статус клиринга
+        /// </summary>
+        CLSTATE,
+        /// <summary>
+        /// Статус торговли инструментом
+        /// </summary>
+        STATUS,
+        /// <summary>
+        /// Дата торгов
+        /// </summary>
+        TRADE_DATE_CODE,
+        /// <summary>
+        /// Bloomberg ID
+        /// </summary>
+        BSID,
+        /// <summary>
+        /// CFI
+        /// </summary>
+        CFI_CODE,
+        /// <summary>
+        /// CUSIP
+        /// </summary>
+        CUSIP,
+        /// <summary>
+        /// ISIN
+        /// </summary>
+        ISINCODE,
+        /// <summary>
+        /// RIC
+        /// </summary>
+        RIC,
+        /// <summary>
+        /// SEDOL
+        /// </summary>
+        SEDOL,
+        /// <summary>
+        /// StockCode
+        /// </summary>
+        STOCKCODE,
+        /// <summary>
+        /// StockName
+        /// </summary>
+        STOCKNAME,
+        /// <summary>
+        /// Агрегированная ставка
+        /// </summary>
+        PERCENTRATE,
+        /// <summary>
+        /// Анонимная торговля
+        /// </summary>
+        ANONTRADE,
+        /// <summary>
+        /// Биржевой сбор (возможно, исключен из активных параметров)
+        /// </summary>
+        EXCH_PAY,
+        /// <summary>
+        /// Время начала аукциона
+        /// </summary>
+        STARTTIME,
+        /// <summary>
+        /// Время окончания аукциона
+        /// </summary>
+        ENDTIME,
+        /// <summary>
+        /// Время последнего изменения
+        /// </summary>
+        CHANGETIME,
+        /// <summary>
+        /// Дисконт1
+        /// </summary>
+        DISCOUNT1,
+        /// <summary>
+        /// Дисконт2
+        /// </summary>
+        DISCOUNT2,
+        /// <summary>
+        /// Дисконт3
+        /// </summary>
+        DISCOUNT3,
+        /// <summary>
+        /// Количество в последней сделке
+        /// </summary>
+        QTY,
+        /// <summary>
+        /// Количество во всех сделках
+        /// </summary>
+        VOLTODAY,
+        /// <summary>
+        /// Количество сделок за сегодня
+        /// </summary>
+        NUMTRADES,
+        /// <summary>
+        /// Комментарий
+        /// </summary>
+        SEC_COMMENT,
+        /// <summary>
+        /// Котировка последнего клиринга
+        /// </summary>
+        CLPRICE,
+        /// <summary>
+        /// Оборот в деньгах
+        /// </summary>
+        VALTODAY,
+        /// <summary>
+        /// Оборот в деньгах последней сделки
+        /// </summary>
+        VALUE,
+        /// <summary>
+        /// Пердыдущая оценка
+        /// </summary>
+        PREVWAPRICE,
+        /// <summary>
+        /// Подтип инструмента
+        /// </summary>
+        SECSUBTYPESTATIC,
+        /// <summary>
+        /// Предыдущая расчетная цена
+        /// </summary>
+        PREVSETTLEPRICE,
+        /// <summary>
+        /// Предыдущий расчетный объем
+        /// </summary>
+        PREVSETTLEVOL,
+        /// <summary>
+        /// Процент изменения от закрытия
+        /// </summary>
+        LASTCHANGE,
+        /// <summary>
+        /// Разница цены последней к предыдущей сделке
+        /// </summary>
+        TRADECHANGE,
+        /// <summary>
+        /// Разница цены последней к предыдущей сессии
+        /// </summary>
+        CHANGE,
+        /// <summary>
+        /// Расчетная цена
+        /// </summary>
+        SETTLEPRICE,
+        /// <summary>
+        /// Реальная расчетная цена
+        /// </summary>
+        R_SETTLEPRICE,
+        /// <summary>
+        /// Регистрационный номер (возможно, исключен из активных параметров)
+        /// </summary>
+        REGNUMBER,
+        /// <summary>
+        /// Средневзвешенная цена
+        /// </summary>
+        WAPRICE,
+        /// <summary>
+        /// Текущая рыночная котировка
+        /// </summary>
+        REALVMPRICE,
+        /// <summary>
+        /// Тип
+        /// </summary>
+        SECTYPE,
+        /// <summary>
+        /// Тип цены фьючерса
+        /// </summary>
+        ISPERCENT,
+
+
+
+
+    }
+}

--- a/src/QuikSharp/TradingFunctions/TradingFunctions.cs
+++ b/src/QuikSharp/TradingFunctions/TradingFunctions.cs
@@ -84,6 +84,7 @@ namespace QuikSharp
         /// <param name="paramName"></param>
         /// <returns></returns>
         Task<ParamTable> GetParamEx(string classCode, string secCode, string paramName);
+        Task<ParamTable> GetParamEx(string classCode, string secCode, ParamNames paramName);
 
         /// <summary>
         /// функция для получения таблицы сделок по заданному инструменту
@@ -101,7 +102,7 @@ namespace QuikSharp
         /// <summary>
         /// функция для получения таблицы сделок номеру заявки
         /// </summary>
-        /// <param name="order_num"></param>
+        /// <param name="orderNum"></param>
         /// <returns></returns>
         Task<List<Trade>> GetTrades_by_OdrerNumber(long orderNum);
 
@@ -254,6 +255,12 @@ namespace QuikSharp
         /// <param name="paramName"></param>
         /// <returns></returns>
         public async Task<ParamTable> GetParamEx(string classCode, string secCode, string paramName)
+        {
+            var response = await QuikService.Send<Message<ParamTable>>(
+                    (new Message<string>(classCode + "|" + secCode + "|" + paramName, "getParamEx"))).ConfigureAwait(false);
+            return response.Data;
+        }
+        public async Task<ParamTable> GetParamEx(string classCode, string secCode, ParamNames paramName)
         {
             var response = await QuikService.Send<Message<ParamTable>>(
                     (new Message<string>(classCode + "|" + secCode + "|" + paramName, "getParamEx"))).ConfigureAwait(false);


### PR DESCRIPTION
Добавлено перечисление ParamNames, для использования в функции GetParamEx вместо указания текстовых наименований запрашиваемых параметров. Использование перечисления позволяет не запоминать как правильно называются эти параметры в Quik`е, тем более что ни в одной справке перечня этих параметров нет. Пример использования данного перечисления можно посмотреть в классе Tool демонстрационного приложения QuikSharpDemo. Старый способ указания параметров также остается работоспособным.