### PR TITLE
All money limits and all futures limits

### DIFF
--- a/src/QuikSharp/TradingFunctions/TradingFunctions.cs
+++ b/src/QuikSharp/TradingFunctions/TradingFunctions.cs
@@ -68,9 +68,19 @@ namespace QuikSharp
         Task<MoneyLimitEx> GetMoneyEx(string firmId, string clientCode, string tag, string currCode, int limitKind);
 
         /// <summary>
+        ///  функция для получения информации по денежным лимитам всех торговых счетов (кроме фьючерсных) и валют
+        ///  Лучшее место для получения связки clientCode + firmid
+        /// </summary>
+        Task<List<MoneyLimitEx>> GetMoneyLimits();
+
+        /// <summary>
         ///  функция для получения информации по фьючерсным лимитам
         /// </summary>
         Task<FuturesLimits> GetFuturesLimit(string firmId, string accId, int limitType, string currCode);
+        /// <summary>
+        ///  функция для получения информации по фьючерсным лимитам всех клиентских счетов
+        /// </summary>
+        Task<List<FuturesLimits>> GetFuturesClientLimits();
         /// <summary>
         ///  функция для получения информации по фьючерсным позициям
         /// </summary>
@@ -311,6 +321,17 @@ namespace QuikSharp
         }
 
         /// <summary>
+        ///  функция для получения информации по денежным лимитам всех торговых счетов (кроме фьючерсных) и валют.
+        ///  Лучшее место для получения связки clientCode + firmid
+        /// </summary>
+        public async Task<List<MoneyLimitEx>> GetMoneyLimits()
+        {
+            var response = await QuikService.Send<Message<List<MoneyLimitEx>>>(
+                (new Message<string>("", "getMoneyLimits"))).ConfigureAwait(false);
+            return response.Data;
+        }
+
+        /// <summary>
         /// Функция заказывает получение параметров Таблицы текущих торгов
         /// </summary>
         /// <param name="classCode"></param>
@@ -405,6 +426,17 @@ namespace QuikSharp
                     (new Message<string>(firmId + "|" + accId + "|" + limitType + "|" + currCode, "getFuturesLimit"))).ConfigureAwait(false);
             return response.Data;
         }
+
+        /// <summary>
+        ///  функция для получения информации по фьючерсным лимитам всех клиентских счетов
+        /// </summary>
+        public async Task<List<FuturesLimits>> GetFuturesClientLimits()
+        {
+            var response = await QuikService.Send<Message<List<FuturesLimits>>>(
+                    (new Message<string>("", "getFuturesClientLimits"))).ConfigureAwait(false);
+            return response.Data;
+        }
+
         /// <summary>
         /// Функция для получения информации по фьючерсным позициям
         /// </summary>

--- a/src/QuikSharp/lua/qsfunctions.lua
+++ b/src/QuikSharp/lua/qsfunctions.lua
@@ -394,6 +394,17 @@ function qsfunctions.getMoneyEx(msg)
     return msg
 end
 
+-- Функция возвращает информацию по всем денежным лимитам.
+function qsfunctions.getMoneyLimits(msg)
+    local limits = {}
+    for i=0,getNumberOf("money_limits")-1 do
+        local limit = getItem("money_limits",i)
+	    table.insert(limits, limit)
+    end
+     msg.data = limits
+    return msg
+end
+
 -- Функция предназначена для получения информации по фьючерсным лимитам.
 function qsfunctions.getFuturesLimit(msg)
     local spl = split(msg.data, "|")
@@ -405,6 +416,17 @@ function qsfunctions.getFuturesLimit(msg)
 		log("Futures limit returns nil", 3)
 		msg.data = nil
 	end
+    return msg
+end
+
+-- Функция возвращает информацию по фьючерсным лимитам для всех торговых счетов.
+function qsfunctions.getFuturesClientLimits(msg)
+    local limits = {}
+    for i=0,getNumberOf("futures_client_limits")-1 do
+        local limit = getItem("futures_client_limits",i)
+	    table.insert(limits, limit)
+    end
+     msg.data = limits
     return msg
 end
 


### PR DESCRIPTION
Implementing ideas from #248:
- money limits and futures limits can be received without providing any information. This is useful for getting all balance a user has with possibility to connect trading account to that balance since money limits have a firmid property and futures limits have firmid & trading account properties.