### PR TITLE
Ability to combine multiple queries into one

### DIFF
--- a/src/QuikSharp/lua/qsfunctions.lua
+++ b/src/QuikSharp/lua/qsfunctions.lua
@@ -215,12 +215,12 @@ function qsfunctions.getSecurityInfoBulk(msg)
 		local class_code, sec_code = spl[1], spl[2]
 
 		local status, security = pcall(getSecurityInfo, class_code, sec_code)
-        if status and security then
+		if status and security then
 			table.insert(result, security)
-		elseif not status then
-			log("Error happened while calling getSecurityInfoBulk with ".. class_code .. "|".. sec_code .. ": ".. security)
-			table.insert(result, json.null)
 		else
+			if not status then
+				log("Error happened while calling getSecurityInfoBulk with ".. class_code .. "|".. sec_code .. ": ".. security)
+			end
 			table.insert(result, json.null)
 		end
 	end

--- a/src/QuikSharp/lua/qsfunctions.lua
+++ b/src/QuikSharp/lua/qsfunctions.lua
@@ -205,6 +205,22 @@ function qsfunctions.getSecurityInfo(msg)
     return msg
 end
 
+--- Функция берет на вход список из элементов в формате class_code|sec_code и возвращает список ответов функции getSecurityInfo. 
+-- Количество бумаг в ответе может быть меньше, чем в запросе, потому что какие-то бумаги могут быть не найдены
+function qsfunctions.getSecurityInfoBulk(msg)
+	local result = {}
+	for i=1,#msg.data do
+		local spl = split(msg.data[i], "|")
+		local class_code, sec_code = spl[1], spl[2]
+		local security = getSecurityInfo(class_code, sec_code)
+		if security then
+			table.insert(result, security)
+		end
+	end
+	msg.data = result
+	return msg
+end
+
 --- Функция предназначена для определения класса по коду инструмента из заданного списка классов.
 function qsfunctions.getSecurityClass(msg)
     local spl = split(msg.data, "|")
@@ -334,12 +350,38 @@ function qsfunctions.paramRequest(msg)
     return msg
 end
 
+--- Функция принимает список строк (JSON Array) в формате class_code|sec_code|param_name, вызывает функцию paramRequest для каждой строки. 
+-- Возвращает список ответов в том же порядке
+function qsfunctions.paramRequestBulk(msg)
+	local result = {}
+	for i=1,#msg.data do
+		local spl = split(msg.data[i], "|")
+		local class_code, sec_code, param_name = spl[1], spl[2], spl[3]
+		table.insert(result, ParamRequest(class_code, sec_code, param_name))
+	end
+	msg.data = result
+	return msg
+end
+
 --- Функция отменяет заказ на получение параметров Таблицы текущих торгов. В случае успешного завершения функция возвращает «true», иначе – «false»
 function qsfunctions.cancelParamRequest(msg)
     local spl = split(msg.data, "|")
     local class_code, sec_code, param_name = spl[1], spl[2], spl[3]
     msg.data = CancelParamRequest(class_code, sec_code, param_name)
     return msg
+end
+
+--- Функция принимает список строк (JSON Array) в формате class_code|sec_code|param_name, вызывает функцию CancelParamRequest для каждой строки.
+-- Возвращает список ответов в том же порядке
+function qsfunctions.cancelParamRequestBulk(msg)
+	local result = {}
+	for i=1,#msg.data do
+		local spl = split(msg.data[i], "|")
+		local class_code, sec_code, param_name = spl[1], spl[2], spl[3]
+		table.insert(result, CancelParamRequest(class_code, sec_code, param_name))
+	end
+	msg.data = result
+	return msg
 end
 
 --- Функция предназначена для получения значений всех параметров биржевой информации из Таблицы текущих значений параметров.
@@ -359,6 +401,19 @@ function qsfunctions.getParamEx2(msg)
     local spl = split(msg.data, "|")
     local class_code, sec_code, param_name = spl[1], spl[2], spl[3]
     msg.data = getParamEx2(class_code, sec_code, param_name)
+    return msg
+end
+
+-- Функция принимает список строк (JSON Array) в формате class_code|sec_code|param_name и возвращает результаты вызова
+-- функции getParamEx2 для каждой строки запроса в виде списка в таком же порядке, как в запросе
+function qsfunctions.getParamEx2Bulk(msg)
+	local result = {}
+	for i=1,#msg.data do
+		local spl = split(msg.data[i], "|")
+		local class_code, sec_code, param_name = spl[1], spl[2], spl[3]
+		table.insert(result, getParamEx2(class_code, sec_code, param_name))
+	end
+	msg.data = result
     return msg
 end
 


### PR DESCRIPTION
This code allows to combine multiple queries to getSecurityInfo,  getParamEx2, paramRequest, cancelParamRequest into one big query. And it gives awesome performance in comparison with requesting the data with different queries one by one.
So, before that downloading all securities I need for working (~600), and subscribing to 10 params, and getting values for all these params took 2-3 seconds (this time includes processing time and getting other important data) on localhost. If I used remote connection via local wifi router all the work could take 2-3 minutes. 

Now in first situation (localhost) it takes 0.5 seconds, in second situation it takes <4 seconds on low end Android device via bad wifi router. So I really impressed with the performance.

I didn't make C# part because I'm working with Lua-only part of the lib. Maybe someone will make a PR once he use the code in his projects.