### PR TITLE
Запрос стопов по id и номеру, полезная информация для лимиток

### DIFF
--- a/src/QuikSharp/DataStructures/Transaction/Order.cs
+++ b/src/QuikSharp/DataStructures/Transaction/Order.cs
@@ -441,5 +441,22 @@ namespace QuikSharp.DataStructures.Transaction
                     ? State.Canceled
                     : State.Completed);
         }
+
+
+        /// <summary>
+        /// Средняя цена заявки. Будет только в том случае, если заявка получена с помощью методов, 
+        /// в названии которых есть `WithInfo`, и только тогда, когда есть хоть одна сделка.
+        /// Вычисляется в Lua коде, а не выдается Quik'ом
+        /// </summary>
+        [JsonProperty("average_price")]
+        public decimal AveragePrice { get; set; }
+
+        /// <summary>
+        /// Время последней сделки в заявке. Будет только в том случае, если заявка получена с помощью методов, 
+        /// в названии которых есть `WithInfo`, и только тогда, когда есть хоть одна сделка.
+        /// Вычисляется в Lua коде, а не выдается Quik'ом
+        /// </summary>
+        [JsonProperty("last_trade_datetime")]
+        public QuikDateTime LastTradeDatetime { get; set; }
     }
 }

--- a/src/QuikSharp/DataStructures/Transaction/Order.cs
+++ b/src/QuikSharp/DataStructures/Transaction/Order.cs
@@ -441,22 +441,5 @@ namespace QuikSharp.DataStructures.Transaction
                     ? State.Canceled
                     : State.Completed);
         }
-
-
-        /// <summary>
-        /// Средняя цена заявки. Будет только в том случае, если заявка получена с помощью методов, 
-        /// в названии которых есть `WithInfo`, и только тогда, когда есть хоть одна сделка.
-        /// Вычисляется в Lua коде, а не выдается Quik'ом
-        /// </summary>
-        [JsonProperty("average_price")]
-        public decimal AveragePrice { get; set; }
-
-        /// <summary>
-        /// Время последней сделки в заявке. Будет только в том случае, если заявка получена с помощью методов, 
-        /// в названии которых есть `WithInfo`, и только тогда, когда есть хоть одна сделка.
-        /// Вычисляется в Lua коде, а не выдается Quik'ом
-        /// </summary>
-        [JsonProperty("last_trade_datetime")]
-        public QuikDateTime LastTradeDatetime { get; set; }
     }
 }

--- a/src/QuikSharp/DataStructures/Transaction/OrderEx.cs
+++ b/src/QuikSharp/DataStructures/Transaction/OrderEx.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) 2014-2020 QUIKSharp Authors https://github.com/finsight/QUIKSharp/blob/master/AUTHORS.md. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE.txt in the project root for license information.
+
+using Newtonsoft.Json;
+
+namespace QuikSharp.DataStructures.Transaction
+{
+    /// <summary>
+    /// Описание параметров Таблицы заявок. Данный класс содержит дополнительные поля, которые вычисляются библиотекой на стороне Lua кода
+    /// </summary>
+    public class OrderEx : Order
+    {
+        /// <summary>
+        /// Средняя цена заявки. Будет только в том случае, если по заявке есть хоть одна сделка
+        /// </summary>
+        [JsonProperty("average_price_ex")]
+        public decimal AveragePriceEx { get; set; }
+
+        /// <summary>
+        /// Время последней сделки в заявке. Будет только в том случае, если по заявке есть хоть одна сделка
+        /// </summary>
+        [JsonProperty("last_trade_datetime_ex")]
+        public QuikDateTime LastTradeDatetimeEx { get; set; }
+    }
+}

--- a/src/QuikSharp/OrderFunctions.cs
+++ b/src/QuikSharp/OrderFunctions.cs
@@ -168,15 +168,16 @@ namespace QuikSharp
 
         /// <summary>
         /// Возвращает заявку из хранилища терминала по её номеру. В заявке будут указаны дополнительные параметры, а именно
-        /// средняя цена и время последней сделки, но только если есть хоть одна сделка
+        /// средняя цена и время последней сделки, но только если есть хоть одна сделка.
+        /// Дополнительные параметры вычисляются в Lua коде, а не выдаются Quik'ом. Это займет чуть больше времени
         /// </summary>
         /// <param name="classCode">Класс инструмента.</param>
         /// <param name="orderNum">Номер заявки.</param>
         /// <returns></returns>
-        public async Task<Order> GetOrderWithInfo(string classCode, long orderNum)
+        public async Task<OrderEx> GetOrderWithInfo(string classCode, long orderNum)
         {
             var message = new Message<string>(classCode + "|" + orderNum, "get_order_with_info_by_number");
-            Message<Order> response = await QuikService.Send<Message<Order>>(message).ConfigureAwait(false);
+            Message<OrderEx> response = await QuikService.Send<Message<OrderEx>>(message).ConfigureAwait(false);
             return response.Data;
         }
 
@@ -193,13 +194,13 @@ namespace QuikSharp
 
         /// <summary>
         /// Возвращает список всех заявок. В них будут указаны средняя цена и время последней сделки, если есть хоть одна сделка.
-        /// Дополнительные параметры просчитываются в Lua коде, а не выдаются Quik'ом. Это займет чуть больше времени
+        /// Дополнительные параметры вычисляются в Lua коде, а не выдаются Quik'ом. Это займет чуть больше времени
         /// </summary>
         /// <returns></returns>
-        public async Task<List<Order>> GetOrdersWithInfo()
+        public async Task<List<OrderEx>> GetOrdersWithInfo()
         {
             var message = new Message<string>("", "getOrdersWithInfo");
-            Message<List<Order>> response = await QuikService.Send<Message<List<Order>>>(message).ConfigureAwait(false);
+            Message<List<OrderEx>> response = await QuikService.Send<Message<List<OrderEx>>>(message).ConfigureAwait(false);
             return response.Data;
         }
 
@@ -216,12 +217,12 @@ namespace QuikSharp
         /// <summary>
         /// Возвращает список заявок для заданного инструмента. В них будут указаны средняя цена и время последней сделки, 
         /// если есть хоть одна сделка.
-        /// Дополнительные параметры просчитываются в Lua коде, а не выдаются Quik'ом. Это займет чуть больше времени
+        /// Дополнительные параметры вычисляются в Lua коде, а не выдаются Quik'ом. Это займет чуть больше времени
         /// </summary>
-        public async Task<List<Order>> GetOrdersWithInfo(string classCode, string securityCode)
+        public async Task<List<OrderEx>> GetOrdersWithInfo(string classCode, string securityCode)
         {
             var message = new Message<string>(classCode + "|" + securityCode, "getOrdersWithInfo");
-            Message<List<Order>> response = await QuikService.Send<Message<List<Order>>>(message).ConfigureAwait(false);
+            Message<List<OrderEx>> response = await QuikService.Send<Message<List<OrderEx>>>(message).ConfigureAwait(false);
             return response.Data;
         }
 
@@ -237,12 +238,13 @@ namespace QuikSharp
 
         /// <summary>
         /// Возвращает заявку для заданного инструмента по ID. В заявке будут указаны дополнительные параметры, а именно
-        /// средняя цена и время последней сделки, но только если есть хоть одна сделка
+        /// средняя цена и время последней сделки, но только если есть хоть одна сделка.
+        /// Дополнительные параметры вычисляются в Lua коде, а не выдаются Quik'ом. Это займет чуть больше времени
         /// </summary>
-        public async Task<Order> GetOrderWithInfoByTransID(string classCode, string securityCode, long transId)
+        public async Task<OrderEx> GetOrderWithInfoByTransID(string classCode, string securityCode, long transId)
         {
             var message = new Message<string>(classCode + "|" + securityCode + "|" + transId, "getOrderWithInfoByID");
-            Message<Order> response = await QuikService.Send<Message<Order>>(message).ConfigureAwait(false);
+            Message<OrderEx> response = await QuikService.Send<Message<OrderEx>>(message).ConfigureAwait(false);
             return response.Data;
         }
 
@@ -258,12 +260,13 @@ namespace QuikSharp
 
         /// <summary>
         /// Возвращает заявку по номеру. В заявке будут указаны дополнительные параметры, а именно
-        /// средняя цена и время последней сделки, но только если есть хоть одна сделка
+        /// средняя цена и время последней сделки, но только если есть хоть одна сделка.
+        /// Дополнительные параметры вычисляются в Lua коде, а не выдаются Quik'ом. Это займет чуть больше времени
         /// </summary>
-        public async Task<Order> GetOrderWithInfoByNumber(long orderNum)
+        public async Task<OrderEx> GetOrderWithInfoByNumber(long orderNum)
         {
             var message = new Message<string>(orderNum.ToString(), "getOrderWithInfoByNumber");
-            Message<Order> response = await QuikService.Send<Message<Order>>(message).ConfigureAwait(false);
+            Message<OrderEx> response = await QuikService.Send<Message<OrderEx>>(message).ConfigureAwait(false);
             return response.Data;
         }
     }

--- a/src/QuikSharp/OrderFunctions.cs
+++ b/src/QuikSharp/OrderFunctions.cs
@@ -167,12 +167,38 @@ namespace QuikSharp
         }
 
         /// <summary>
+        /// Возвращает заявку из хранилища терминала по её номеру. В заявке будут указаны дополнительные параметры, а именно
+        /// средняя цена и время последней сделки, но только если есть хоть одна сделка
+        /// </summary>
+        /// <param name="classCode">Класс инструмента.</param>
+        /// <param name="orderNum">Номер заявки.</param>
+        /// <returns></returns>
+        public async Task<Order> GetOrderWithInfo(string classCode, long orderNum)
+        {
+            var message = new Message<string>(classCode + "|" + orderNum, "get_order_with_info_by_number");
+            Message<Order> response = await QuikService.Send<Message<Order>>(message).ConfigureAwait(false);
+            return response.Data;
+        }
+
+        /// <summary>
         /// Возвращает список всех заявок.
         /// </summary>
         /// <returns></returns>
         public async Task<List<Order>> GetOrders()
         {
             var message = new Message<string>("", "get_orders");
+            Message<List<Order>> response = await QuikService.Send<Message<List<Order>>>(message).ConfigureAwait(false);
+            return response.Data;
+        }
+
+        /// <summary>
+        /// Возвращает список всех заявок. В них будут указаны средняя цена и время последней сделки, если есть хоть одна сделка.
+        /// Дополнительные параметры просчитываются в Lua коде, а не выдаются Quik'ом. Это займет чуть больше времени
+        /// </summary>
+        /// <returns></returns>
+        public async Task<List<Order>> GetOrdersWithInfo()
+        {
+            var message = new Message<string>("", "getOrdersWithInfo");
             Message<List<Order>> response = await QuikService.Send<Message<List<Order>>>(message).ConfigureAwait(false);
             return response.Data;
         }
@@ -188,6 +214,18 @@ namespace QuikSharp
         }
 
         /// <summary>
+        /// Возвращает список заявок для заданного инструмента. В них будут указаны средняя цена и время последней сделки, 
+        /// если есть хоть одна сделка.
+        /// Дополнительные параметры просчитываются в Lua коде, а не выдаются Quik'ом. Это займет чуть больше времени
+        /// </summary>
+        public async Task<List<Order>> GetOrdersWithInfo(string classCode, string securityCode)
+        {
+            var message = new Message<string>(classCode + "|" + securityCode, "getOrdersWithInfo");
+            Message<List<Order>> response = await QuikService.Send<Message<List<Order>>>(message).ConfigureAwait(false);
+            return response.Data;
+        }
+
+        /// <summary>
         /// Возвращает заявку для заданного инструмента по ID.
         /// </summary>
         public async Task<Order> GetOrder_by_transID(string classCode, string securityCode, long trans_id)
@@ -198,11 +236,33 @@ namespace QuikSharp
         }
 
         /// <summary>
+        /// Возвращает заявку для заданного инструмента по ID. В заявке будут указаны дополнительные параметры, а именно
+        /// средняя цена и время последней сделки, но только если есть хоть одна сделка
+        /// </summary>
+        public async Task<Order> GetOrderWithInfoByTransID(string classCode, string securityCode, long transId)
+        {
+            var message = new Message<string>(classCode + "|" + securityCode + "|" + transId, "getOrderWithInfoByID");
+            Message<Order> response = await QuikService.Send<Message<Order>>(message).ConfigureAwait(false);
+            return response.Data;
+        }
+
+        /// <summary>
         /// Возвращает заявку по номеру.
         /// </summary>
         public async Task<Order> GetOrder_by_Number(long order_num)
         {
             var message = new Message<string>(order_num.ToString(), "getOrder_by_Number");
+            Message<Order> response = await QuikService.Send<Message<Order>>(message).ConfigureAwait(false);
+            return response.Data;
+        }
+
+        /// <summary>
+        /// Возвращает заявку по номеру. В заявке будут указаны дополнительные параметры, а именно
+        /// средняя цена и время последней сделки, но только если есть хоть одна сделка
+        /// </summary>
+        public async Task<Order> GetOrderWithInfoByNumber(long orderNum)
+        {
+            var message = new Message<string>(orderNum.ToString(), "getOrderWithInfoByNumber");
             Message<Order> response = await QuikService.Send<Message<Order>>(message).ConfigureAwait(false);
             return response.Data;
         }

--- a/src/QuikSharp/StopOrderFunctions.cs
+++ b/src/QuikSharp/StopOrderFunctions.cs
@@ -53,6 +53,26 @@ namespace QuikSharp
             return response.Data;
         }
 
+        /// <summary>
+        /// Возвращает стоп заявку для заданного инструмента по ID.
+        /// </summary>
+        public async Task<StopOrder> GetStopOrderByTransID(string classCode, string securityCode, long transId)
+        {
+            var message = new Message<string>(classCode + "|" + securityCode + "|" + transId, "getStopOrderByID");
+            Message<StopOrder> response = await QuikService.Send<Message<StopOrder>>(message).ConfigureAwait(false);
+            return response.Data;
+        }
+
+        /// <summary>
+        /// Возвращает стоп заявку по номеру.
+        /// </summary>
+        public async Task<StopOrder> GetStopOrderByNumber(long stopOrderNum)
+        {
+            var message = new Message<string>(stopOrderNum.ToString(), "getStopOrderByNumber");
+            Message<StopOrder> response = await QuikService.Send<Message<StopOrder>>(message).ConfigureAwait(false);
+            return response.Data;
+        }
+
         public async Task<long> CreateStopOrder(StopOrder stopOrder)
         {
             Transaction newStopOrderTransaction = new Transaction

--- a/src/QuikSharp/lua/qsfunctions.lua
+++ b/src/QuikSharp/lua/qsfunctions.lua
@@ -543,11 +543,11 @@ function fillOrderWithTradesData(order)
 		if trade.order_num == order.order_num then
 			price_qty = price_qty + trade.price * trade.qty
 			qty_of_trades = qty_of_trades + trade.qty
-			order.last_trade_datetime = trade.datetime
+			order.last_trade_datetime_ex = trade.datetime
 		end
 	end
 	if qty_of_trades > 0 then
-		order.average_price = price_qty / qty_of_trades
+		order.average_price_ex = price_qty / qty_of_trades
 	end
 	return order
 end

--- a/src/QuikSharp/lua/qsfunctions.lua
+++ b/src/QuikSharp/lua/qsfunctions.lua
@@ -525,17 +525,17 @@ function qsfunctions.get_orders(msg)
 end
 
 --- Функция возвращает таблицу заявок (всю или по заданному инструменту) вместе с датой последней сделки и средней ценой
-function qsfunctions.get_orders_with_info(msg)
+function qsfunctions.getOrdersWithInfo(msg)
 	qsfunctions.get_orders(msg)
 	for i = 1, #msg.data do
-		fill_order_with_trades_data(msg.data[i])
+		fillOrderWithTradesData(msg.data[i])
 	end
 	return msg
 end
 
 -- Заполняет заявку полезными деталями: средней ценой с произвольным количеством цифр после запятой и временем последней сделки.
 -- В случае, если сделок не было, эти поля будут отсутствовать в ответе
-function fill_order_with_trades_data(order)
+function fillOrderWithTradesData(order)
 	local qty_of_trades = 0
 	local price_qty = 0
 	for i = 0, getNumberOf("trades") - 1 do
@@ -573,10 +573,10 @@ function qsfunctions.getOrder_by_ID(msg)
 end
 
 -- Функция возвращает заявку по заданному инструменту и ID-транзакции вместе с датой последней сделки и средней ценой
-function qsfunctions.getOrder_with_info_by_ID(msg)
+function qsfunctions.getOrderWithInfoByID(msg)
 	qsfunctions.getOrder_by_ID(msg)
 	if type(msg.data) == "table" then
-		fill_order_with_trades_data(msg.data)
+		fillOrderWithTradesData(msg.data)
 	end
 	return msg
 end
@@ -594,10 +594,14 @@ function qsfunctions.getOrder_by_Number(msg)
 end
 
 ---- Функция возвращает заявку по номеру вместе с датой последней сделки и средней ценой
-function qsfunctions.getOrder_with_info_by_Number(msg)
+function qsfunctions.getOrderWithInfoByNumber(msg)
 	qsfunctions.getOrder_by_Number(msg)
 	if type(msg.data) == "table" then
-		fill_order_with_trades_data(msg.data)
+		fillOrderWithTradesData(msg.data)
+	end
+	-- Возвращает nil, если ордер не найден
+	if type(msg.data) == "string" then
+		msg.data = nil
 	end
 	return msg
 end
@@ -616,7 +620,7 @@ end
 function qsfunctions.get_order_with_info_by_number(msg)
 	qsfunctions.get_order_by_number(msg)
 	if type(msg.data) == "table" then
-		fill_order_with_trades_data(msg.data)
+		fillOrderWithTradesData(msg.data)
 	end
 	return msg
 end
@@ -762,13 +766,15 @@ function qsfunctions.get_stop_orders(msg)
 end
 
 -- Функция возвращает стоп заявку по заданному инструменту и ID-транзакции
-function qsfunctions.getStopOrder_by_ID(msg)
+function qsfunctions.getStopOrderByID(msg)
 	if msg.data ~= "" then
 		local spl = split(msg.data, "|")
 		class_code, sec_code, trans_id = spl[1], spl[2], spl[3]
 	end
 
 	local order_num = 0
+	-- Если ордер не будет найден, вернет nil
+	msg.data = nil
 	for i = 0, getNumberOf("stop_orders") - 1 do
 		local order = getItem("stop_orders", i)
 		if order.class_code == class_code and order.sec_code == sec_code and order.trans_id == tonumber(trans_id) and order.order_num > order_num then
@@ -780,10 +786,13 @@ function qsfunctions.getStopOrder_by_ID(msg)
 end
 
 ---- Функция возвращает стоп заявку по номеру
-function qsfunctions.getStopOrder_by_Number(msg)
+function qsfunctions.getStopOrderByNumber(msg)
+	local order_number = tonumber(msg.data)
+	-- Если ордер не будет найден, вернет nil
+	msg.data = nil
 	for i = 0, getNumberOf("stop_orders") - 1 do
 		local order = getItem("stop_orders", i)
-		if order.order_num == tonumber(msg.data) then
+		if order.order_num == order_number then
 			msg.data = order
 			return msg
 		end


### PR DESCRIPTION
Привет. Так как у меня программа построена на идее, что всегда у ордеров есть средняя цена и время последнего действия с ордером, я внес это в код Lua. Теперь есть отдельные функции для получения этой информации и не будет путаницы, старый код не изменен.
То есть, теперь можно сказать: дай-ка мне вот такой ордер и чтобы в нем была доп. информация (average_price и last_trade_timestamp). В будущем, туда можно добавить еще параметров, но лично я не знаю, каких. Этих вполне достаточно. Получается, на четыре функции запроса лимиток четыре альтернативные функции.
Также добавил функции для поиска стопов: все также, по id и number, как лимитки. Итого еще две функции. Но тут уже без доп. информации, так как сделки привязаны именно к number лимиток, а не стопов. При желании, можно у стопа взять number привязанного ордера и получить по уже известным функциям всю инфу. 

Внимания заслуживает, пожалуй, деление для определения средней цены. Судя по всему, lua обрезает результат до приемлемых значений: 14 цифр после запятой при делении `1 / 3`. Соответственно, при делении `100 / 3` уже 12 после запятой. А значит в double укладываемся.

Для проверки вводил тут https://www.lua.org/cgi-bin/demo   и непосредственнно в код вносил и смотрел, как все парсится на клиенте. Клиенту приходит именно как число, а не как строка. 

Вот тут
https://github.com/finsight/QUIKSharp/compare/master...avently:stop_orders_and_info?expand=1#diff-099a2ee246ff86904fb6e124391d3304R774
Я скопипастил поведение для поиска лимиток по id. Я правильно понимаю, такой подход тут нужен потому, что id могут повторятся у разных ордеров и мы просто ищем самый "свежий" из всех?

В общем, должно все работать хорошо. Если что, я буду активным пользователем данных функций и, если что-то сломается, внесу правки.