### PR TITLE
fixed GetQuoteLevel2 lua function

### DIFF
--- a/src/QuikSharp/lua/qsfunctions.lua
+++ b/src/QuikSharp/lua/qsfunctions.lua
@@ -335,7 +335,6 @@ function qsfunctions.GetQuoteLevel2(msg)
         msg.data.class_code		= class_code
         msg.data.sec_code		= sec_code
         msg.data.server_time	= server_time
-        sendCallback(msg)
     else
         OnError(ql2)
     end


### PR DESCRIPTION
**Ошибка:** Функция qsfunctions.GetQuoteLevel2() вызывала ошибку в C# клиенте из-за вызова коллбэка с неправильными параметрами.

Насколько я понимаю:
1. Коллбэк вызывается автоматически при поступлении стакана из функции OnQuote
2. GetQuoteLevel2 должен просто получать текущий стакан и вернуть его

Поэтому мне кажется, тут просто скопипастили лишнюю строчку из функции OnQuote. Я удалил ненужный коллбэк-вызов, и все заработало.