### PR TITLE
fix: метод SendOrder зависает, когда транзакция закончилась неудачей

### DIFF
--- a/src/QuikSharp/DataStructures/Transaction/Transaction.cs
+++ b/src/QuikSharp/DataStructures/Transaction/Transaction.cs
@@ -32,7 +32,8 @@ namespace QuikSharp.DataStructures.Transaction
         /// <summary>
         /// TransactionReply
         /// </summary>
-        public TransactionReply TransactionReply { get; set; }
+        volatile TransactionReply _transactionReply;
+        public TransactionReply TransactionReply { get => _transactionReply; set { _transactionReply = value; } }
 
         /// <summary>
         /// Функция вызывается терминалом QUIK при получении новой заявки или при изменении параметров существующей заявки.


### PR DESCRIPTION
Иногда бывают ситуации, когда заявка не может быть выставлена. Например, не все инструменты торгуются в вечернюю сессию:

![image](https://user-images.githubusercontent.com/18679813/101927338-69973980-3be5-11eb-8691-d1a22a011c41.png)

В таких ситуациях метод SendOrder просто зависает.

Также в этом исправлении я вернул в метод SendOrder задержку Thread.Sleep() - по-моему, нужна хотя бы минимальная задержка, потому что обычно в таких циклах наблюдается 100% загрузка CPU. Поправьте, если я не прав. :)