### PR TITLE
Feature: breaking changes and new StopOrder functions

### DIFF
--- a/src/QuikSharp/DataStructures/StopOrder.cs
+++ b/src/QuikSharp/DataStructures/StopOrder.cs
@@ -77,6 +77,13 @@ namespace QuikSharp.DataStructures
         public string ClassCode { get; set; }
 
         /// <summary>
+        /// Дата и время выставления стоп-заявки
+        /// </summary>
+        [JsonProperty("order_date_time")]
+        public QuikDateTime Datetime { get; set; }
+
+
+        /// <summary>
         /// Отступ от min/max
         /// </summary>
         [JsonProperty("offset")]

--- a/src/QuikSharp/DataStructures/Transaction/Transaction.cs
+++ b/src/QuikSharp/DataStructures/Transaction/Transaction.cs
@@ -32,7 +32,8 @@ namespace QuikSharp.DataStructures.Transaction
         /// <summary>
         /// TransactionReply
         /// </summary>
-        public TransactionReply TransactionReply { get; set; }
+        volatile TransactionReply _transactionReply;
+        public TransactionReply TransactionReply { get => _transactionReply; set { _transactionReply = value; } }
 
         /// <summary>
         /// Функция вызывается терминалом QUIK при получении новой заявки или при изменении параметров существующей заявки.

--- a/src/QuikSharp/QuikEvents.cs
+++ b/src/QuikSharp/QuikEvents.cs
@@ -483,12 +483,13 @@ namespace QuikSharp
             OnTransReply?.Invoke(reply);
 
             // invoke event specific for the transaction
-            if (string.IsNullOrEmpty(reply.Comment)) //"Initialization user successful" transaction doesn't contain comment
-                return;
 
-            if (QuikService.Storage.Contains(reply.Comment))
+
+            var transId = reply.TransID.ToString();
+
+            if (QuikService.Storage.Contains(transId))
             {
-                var tr = QuikService.Storage.Get<Transaction>(reply.Comment);
+                var tr = QuikService.Storage.Get<Transaction>(transId);
                 lock (tr)
                 {
                     tr.OnTransReplyCall(reply);

--- a/src/QuikSharp/QuikService.cs
+++ b/src/QuikSharp/QuikService.cs
@@ -791,7 +791,7 @@ namespace QuikSharp
             }
             else
             {
-                if (newId >= 2147483638) newId = 100;
+                if (newId >= 2147483637 || newId < 1) newId = 100;
                 newId++;
             }
 

--- a/src/QuikSharp/StopOrderFunctions.cs
+++ b/src/QuikSharp/StopOrderFunctions.cs
@@ -5,6 +5,7 @@ using QuikSharp.DataStructures;
 using QuikSharp.DataStructures.Transaction;
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace QuikSharp
@@ -53,6 +54,10 @@ namespace QuikSharp
             return response.Data;
         }
 
+        /// <summary>
+        /// Регистрирует стоп-заявку.
+        /// </summary>
+        /// <returns>Номер транзакции.</returns>
         public async Task<long> CreateStopOrder(StopOrder stopOrder)
         {
             Transaction newStopOrderTransaction = new Transaction
@@ -94,6 +99,99 @@ namespace QuikSharp
             return await Quik.Trading.SendTransaction(newStopOrderTransaction).ConfigureAwait(false);
         }
 
+        /// <summary>
+        /// Возвращает стоп-заявку для заданного инструмента по ID.
+        /// </summary>
+        public async Task<StopOrder> GetStopOrder_by_transID(string classCode, string securityCode, long trans_id)
+        {
+            var message = new Message<string>(classCode + "|" + securityCode + "|" + trans_id, "getStopOrder_by_ID");
+            Message<StopOrder> response = await QuikService.Send<Message<StopOrder>>(message).ConfigureAwait(false);
+            return response.Data;
+        }
+
+        /// <summary>
+        /// Возвращает стоп-заявку по номеру.
+        /// </summary>
+        public async Task<StopOrder> GetStopOrder_by_Number(long order_num)
+        {
+            var message = new Message<string>(order_num.ToString(), "getStopOrder_by_Number");
+            Message<StopOrder> response = await QuikService.Send<Message<StopOrder>>(message).ConfigureAwait(false);
+            return response.Data;
+        }
+
+        /// <summary>
+        /// Регистрирует стоп-заявку и дожидается исполнения транзакции. В случае ошибки выкидывает исключение.
+        /// </summary>        
+        /// <returns>Зарегистрированный стоп-ордер.</returns>
+        public async Task<StopOrder> CreateStopOrderOrThrow(StopOrder stopOrder)
+        {
+            Transaction newStopOrderTransaction = new Transaction
+            {
+                ACTION = TransactionAction.NEW_STOP_ORDER,
+                ACCOUNT = stopOrder.Account,
+                CLIENT_CODE = stopOrder.ClientCode,
+                CLASSCODE = stopOrder.ClassCode,
+                SECCODE = stopOrder.SecCode,
+                EXPIRY_DATE = "GTC", //до отмены
+                STOPPRICE = stopOrder.ConditionPrice,
+                PRICE = stopOrder.Price,
+                QUANTITY = stopOrder.Quantity,
+                STOP_ORDER_KIND = ConvertStopOrderType(stopOrder.StopOrderType),
+                OPERATION = stopOrder.Operation == Operation.Buy ? TransactionOperation.B : TransactionOperation.S
+            };
+            if (stopOrder.StopOrderType == StopOrderType.TakeProfit || stopOrder.StopOrderType == StopOrderType.TakeProfitStopLimit)
+            {
+                newStopOrderTransaction.OFFSET = stopOrder.Offset;
+                newStopOrderTransaction.SPREAD = stopOrder.Spread;
+                newStopOrderTransaction.OFFSET_UNITS = stopOrder.OffsetUnit;
+                newStopOrderTransaction.SPREAD_UNITS = stopOrder.SpreadUnit;
+            }
+
+            if (stopOrder.StopOrderType == StopOrderType.TakeProfitStopLimit)
+            {
+                newStopOrderTransaction.STOPPRICE2 = stopOrder.ConditionPrice2;
+            }
+
+            //todo: Not implemented
+            //  ...see CreateStopOrder() method
+
+            long res = 0;
+            try
+            {
+                res = await Quik.Trading.SendTransaction(newStopOrderTransaction).ConfigureAwait(false);
+                Thread.Sleep(500);
+                Console.WriteLine("res: " + res);
+            }
+            catch
+            {
+                //ignore
+            }
+
+            if (res < 0)
+                throw new InvalidOperationException($"StopOrder {stopOrder.SecCode}@{stopOrder.ClassCode} {stopOrder.Operation} {stopOrder.StopOrderType} registering failed. {newStopOrderTransaction.ErrorMessage}");
+
+            while (true)
+            {
+                if (newStopOrderTransaction.TransactionReply != null && newStopOrderTransaction.TransactionReply.ErrorSource != 0)
+                    throw new InvalidOperationException(!string.IsNullOrEmpty(newStopOrderTransaction.TransactionReply.ResultMsg)
+                      ? $"StopOrder {stopOrder.SecCode}@{stopOrder.ClassCode} {stopOrder.Operation} {stopOrder.StopOrderType} registering failed. {newStopOrderTransaction.TransactionReply.ResultMsg}"
+                      : $"StopOrder {stopOrder.SecCode}@{stopOrder.ClassCode} {stopOrder.Operation} {stopOrder.StopOrderType} registering failed. Transaction {res} error: code {newStopOrderTransaction.TransactionReply.ErrorCode}, source {newStopOrderTransaction.TransactionReply.ErrorSource}");
+
+                try
+                {
+                    var result = await Quik.StopOrders.GetStopOrder_by_transID(stopOrder.ClassCode, stopOrder.SecCode, res).ConfigureAwait(false);
+                    if (result != null)
+                        return result;
+                }
+                catch (Exception e)
+                {
+                    throw new InvalidOperationException($"StopOrder {stopOrder.SecCode}@{stopOrder.ClassCode} {stopOrder.Operation} {stopOrder.StopOrderType} registering failed. Неудачная попытка получения заявки по ID-транзакции №{res}, {e.Message}");
+                }
+
+                Thread.Sleep(10);
+            }
+        }
+
         private StopOrderKind ConvertStopOrderType(StopOrderType stopOrderType)
         {
             switch (stopOrderType)
@@ -112,6 +210,11 @@ namespace QuikSharp
             }
         }
 
+        /// <summary>
+        /// Отмена стоп-заявки.
+        /// </summary>
+        /// <param name="stopOrder">Информация по стоп-заявке, которую требуется отменить.</param>
+        /// <returns>Номер транзакции</returns>
         public async Task<long> KillStopOrder(StopOrder stopOrder)
         {
             Transaction killStopOrderTransaction = new Transaction
@@ -122,6 +225,31 @@ namespace QuikSharp
                 STOP_ORDER_KEY = stopOrder.OrderNum.ToString()
             };
             return await Quik.Trading.SendTransaction(killStopOrderTransaction).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Отмена стоп-заявки с ожиданием завершения транзакции.
+        /// </summary>
+        /// <param name="stopOrder">Информация по стоп-заявке, которую требуется отменить.</param>
+        /// <returns>Результат выполнения транзакции</returns>
+        public async Task<TransactionReply> KillStopOrderEx(StopOrder stopOrder)
+        {
+            Transaction killStopOrderTransaction = new Transaction
+            {
+                ACTION = TransactionAction.KILL_STOP_ORDER,
+                CLASSCODE = stopOrder.ClassCode,
+                SECCODE = stopOrder.SecCode,
+                STOP_ORDER_KEY = stopOrder.OrderNum.ToString()
+            };
+
+            var res = await Quik.Trading.SendTransaction(killStopOrderTransaction).ConfigureAwait(false);
+            if (res < 0)
+                return null;
+
+            while (killStopOrderTransaction.TransactionReply == null)
+                Thread.Sleep(10);
+
+            return killStopOrderTransaction.TransactionReply;
         }
     }
 }

--- a/src/QuikSharp/lua/qsfunctions.lua
+++ b/src/QuikSharp/lua/qsfunctions.lua
@@ -543,9 +543,10 @@ function qsfunctions.getOrder_by_ID(msg)
 		class_code, sec_code, trans_id = spl[1], spl[2], spl[3]
 	end
 
+  local count = getNumberOf("orders")
 	local order_num = 0
 	local res
-	for i = 0, getNumberOf("orders") - 1 do
+	for i = 0, count - 1 do
 		local order = getItem("orders", i)
 		if order.class_code == class_code and order.sec_code == sec_code and order.trans_id == tonumber(trans_id) and order.order_num > order_num then
 			order_num = order.order_num
@@ -717,6 +718,40 @@ function qsfunctions.get_stop_orders(msg)
 	msg.data = stop_orders
 	return msg
 end
+
+-- Функция возвращает стоп-заявку по заданному инструменту и ID-транзакции
+function qsfunctions.getStopOrder_by_ID(msg)
+	if msg.data ~= "" then
+		local spl = split(msg.data, "|")
+		class_code, sec_code, trans_id = spl[1], spl[2], spl[3]
+	end
+
+	local count = getNumberOf("stop_orders")
+  local order_num = 0
+	local res
+	for i = 0, count - 1 do
+		local stop_order = getItem("stop_orders", i)
+		if stop_order.class_code == class_code and stop_order.sec_code == sec_code and stop_order.trans_id == tonumber(trans_id) and stop_order.order_num > order_num then
+			order_num = stop_order.order_num
+			res = stop_order
+		end
+	end
+	msg.data = res
+	return msg
+end
+
+---- Функция возвращает заявку по номеру
+function qsfunctions.getStopOrder_by_Number(msg)
+	for i=0,getNumberOf("stop_orders")-1 do
+		local order = getItem("stop_orders",i)
+		if order.order_num == tonumber(msg.data) then
+			msg.data = order
+			return msg
+		end
+	end
+	return msg
+end
+
 
 -------------------------
 --- Candles functions ---


### PR DESCRIPTION
Добрый день. У меня накопились исправления и новый функционал, которым я пользуюсь. Необходимо потестировать - либо дописать автотесты, либо погонять руками в рамках своих приложений. (Я пока не смотрел, как здесь устроены автотесты, но попробую разобраться с ними и дописать, если это возможно.

**Новый функционал:**

`StopOrderFunctions class - GetStopOrder_by_transID(), GetStopOrder_by_Number(), CreateStopOrderOrThrow(), KillStopOrderEx() methods`
`OrderFunctions class - KillOrderEx() method`
`StopOrder class - Datetime property`

**BreakingChanges:**

1. Зоопарк из `reply.Comment`, `CLIENT_CODE` и `TRANS_ID` (в связке `TradingFunctions.SendTransaction()` -  `QuikEvents.OnTransReplyCall()`) заменил на `TRANS_ID`.

Пояснение.

При отладке новых методов `StopOrderFunctions` в коллбэке `QuikEvents.OnTransReplyCall()` не обнаруживалась транзакция. А мне надо положить в нее `TransactionReply`, чтобы корректно завершилось ожидание транзакции, например, в `CreateStopOrderOrThrow()`. Причина в том, что `TradingFunctions.SendTransaction()` сохраняет транзакцию под `CLIENT_CODE (или TRANS_ID)`

> `QuikService.Storage.Set(transaction.CLIENT_CODE, transaction);`

а QuikEvents.OnTransReply() ищет ее под `reply.Comment`

> `QuikService.Storage.Get<Transaction>(reply.Comment);`

`reply.Comment` часто приходит пустой.

Я почитал две ветки обсуждений этого зоопарка из `reply.Comment`, `CLIENT_CODE` и `TRANS_ID`, но так и не нашел рациональную причину его возникновения ([issue #264](https://github.com/finsight/QUIKSharp/issues/264), [issue #269](https://github.com/finsight/QUIKSharp/issues/269)).  Поэтому исходя из того, что QUIKSharp предназначен для использования в однопоточном режиме (т.е. требуется внешняя синхронизация как минимум для выставления транзакций), и за 1 момент времени выставляется 1 заявка, я переписал все просто на `TRANS_ID`. И теперь надо потестировать, у кого что сломалось. :) У меня корректно работают все используемые мною функции, связанные с TRANS_ID - отправка/отмена лимитных и рыночных ордеров, а также стоп-заявок в синхронизированном режиме (т.е. с ожиданием выполнения каждой транзакции).

**Дополнение.** Отправленные `Transaction` будут бесконечно накапливаться в `QuikService.Storage`. Я пока не задумывался над его очисткой, т.к. в моем случае их количество достаточно мало, чтобы влиять на память/производительность робота.

2. В `OrderFunctions` в методы `SendOrder(), SendMarketOrder(), SendLimitOrder()` добавлен параметр `clientCode`

На площадке "Фондовый рынок" Московской биржи у меня всегда требуется код клиента.